### PR TITLE
Multiple Pool

### DIFF
--- a/Hastructure.cabal
+++ b/Hastructure.cabal
@@ -81,6 +81,7 @@ library
     , servant-errors
     , servant-openapi3
     , servant-server
+    , split
     , swagger2
     , template-haskell
     , text
@@ -119,6 +120,7 @@ executable Hastructure-exe
     , servant-errors
     , servant-openapi3
     , servant-server
+    , split
     , string-conversions
     , swagger2
     , template-haskell
@@ -171,6 +173,7 @@ test-suite Hastructure-test
     , servant-errors
     , servant-openapi3
     , servant-server
+    , split
     , swagger2
     , tasty
     , tasty-golden

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -115,6 +115,7 @@ data DealType = MDeal (DB.TestDeal AB.Mortgage)
               | IDeal (DB.TestDeal AB.Installment) 
               | RDeal (DB.TestDeal AB.Lease) 
               | FDeal (DB.TestDeal AB.FixedAsset) 
+              | UDeal (DB.TestDeal AB.AssetUnion) 
               deriving(Show, Generic)
 
 instance ToSchema Ts
@@ -137,12 +138,15 @@ instance ToSchema (DB.TestDeal AB.Mortgage)
 instance ToSchema (DB.TestDeal AB.Loan)
 instance ToSchema (DB.TestDeal AB.Installment)
 instance ToSchema (DB.TestDeal AB.Lease)
+instance ToSchema (DB.TestDeal AB.AssetUnion)
 instance ToSchema (DB.TestDeal AB.FixedAsset)
+instance ToSchema (DB.PoolType AB.AssetUnion)
 instance ToSchema (DB.PoolType AB.FixedAsset)
 instance ToSchema (DB.PoolType AB.Mortgage)
 instance ToSchema (DB.PoolType AB.Loan)
 instance ToSchema (DB.PoolType AB.Installment)
 instance ToSchema (DB.PoolType AB.Lease)
+instance ToSchema (P.Pool AB.AssetUnion)
 instance ToSchema HE.RateCap
 instance ToSchema AB.LeaseStepUp 
 instance ToSchema AB.AccrualPeriod
@@ -261,6 +265,10 @@ wrapRun (FDeal d) mAssump mNonPerfAssump = let
                                        (_d,_pflow,_rs,_p) = D.runDeal d D.DealPoolFlowPricing mAssump mNonPerfAssump
                                      in 
                                        (FDeal _d,_pflow,_rs,_p)
+wrapRun (UDeal d) mAssump mNonPerfAssump = let 
+                                       (_d,_pflow,_rs,_p) = D.runDeal d D.DealPoolFlowPricing mAssump mNonPerfAssump
+                                     in 
+                                       (UDeal _d,_pflow,_rs,_p)                                       
 wrapRun x _ _ = error $ "RunDeal Failed ,due to unsupport deal type "++ show x
 
 wrapRunPool :: PoolType -> Maybe AP.ApplyAssumptionType -> Maybe [RateAssumption] -> (CF.CashFlowFrame, Map CutoffFields Balance)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -82,7 +82,6 @@ import qualified DateUtil as DU
 
 
 import Debug.Trace
-import qualified Hedge as HE
 debug = flip Debug.Trace.trace
 
 data Version = Version 
@@ -139,6 +138,12 @@ instance ToSchema (DB.TestDeal AB.Loan)
 instance ToSchema (DB.TestDeal AB.Installment)
 instance ToSchema (DB.TestDeal AB.Lease)
 instance ToSchema (DB.TestDeal AB.FixedAsset)
+instance ToSchema DB.PoolId
+instance ToSchema (DB.PoolType AB.Mortgage)
+instance ToSchema (DB.PoolType AB.Loan)
+instance ToSchema (DB.PoolType AB.Installment)
+instance ToSchema (DB.PoolType AB.Lease)
+instance ToSchema (DB.PoolType AB.FixedAsset)
 instance ToSchema HE.RateCap
 instance ToSchema AB.LeaseStepUp 
 instance ToSchema AB.AccrualPeriod

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -138,12 +138,11 @@ instance ToSchema (DB.TestDeal AB.Loan)
 instance ToSchema (DB.TestDeal AB.Installment)
 instance ToSchema (DB.TestDeal AB.Lease)
 instance ToSchema (DB.TestDeal AB.FixedAsset)
-instance ToSchema DB.PoolId
+instance ToSchema (DB.PoolType AB.FixedAsset)
 instance ToSchema (DB.PoolType AB.Mortgage)
 instance ToSchema (DB.PoolType AB.Loan)
 instance ToSchema (DB.PoolType AB.Installment)
 instance ToSchema (DB.PoolType AB.Lease)
-instance ToSchema (DB.PoolType AB.FixedAsset)
 instance ToSchema HE.RateCap
 instance ToSchema AB.LeaseStepUp 
 instance ToSchema AB.AccrualPeriod
@@ -185,6 +184,7 @@ instance ToSchema OverrideType
 instance ToSchema ActionOnDate
 instance ToSchema DealStats
 instance ToSchema Period
+instance ToSchema PoolId
 instance ToSchema DayCount
 instance ToSchema DealStatus
 instance ToSchema DatePattern
@@ -238,7 +238,7 @@ instance ToSchema (Ratio Integer) where
 instance ToSchema PoolSource
 instance ToSchema Threshold
 
-type RunResp = (DealType , Maybe CF.CashFlowFrame, Maybe [ResultComponent],Maybe (Map.Map String L.PriceResult))
+type RunResp = (DealType , Maybe (Map.Map PoolId CF.CashFlowFrame), Maybe [ResultComponent],Maybe (Map.Map String L.PriceResult))
 
 wrapRun :: DealType -> Maybe AP.ApplyAssumptionType -> AP.NonPerfAssumption -> RunResp
 wrapRun (MDeal d) mAssump mNonPerfAssump = let 

--- a/package.yaml
+++ b/package.yaml
@@ -41,6 +41,7 @@ dependencies:
 - servant-errors
 - openapi3
 - swagger2
+- split
 
 library:
   source-dirs: 

--- a/src/Accounts.hs
+++ b/src/Accounts.hs
@@ -29,14 +29,14 @@ debug = flip trace
 
 data InterestInfo = BankAccount IRate Date DatePattern                -- ^ fix reinvest return rate
                   | InvestmentAccount Types.Index Spread Date DatePattern   -- ^ float reinvest return rate (index,spread, dp)
-                  deriving (Show, Generic)
+                  deriving (Show, Generic,Eq,Ord)
 
 data ReserveAmount = PctReserve DealStats Rate               -- ^ target amount with reference to % of formula
                    | FixReserve Balance                      -- ^ target amount with fixed balance amount    
                    | Either Pre ReserveAmount ReserveAmount  -- ^ target amount depends on a test, if true, then use first one ,otherwise use second one
                    | Max [ReserveAmount]                     -- ^ use higher of all reserve formulas
                    | Min [ReserveAmount]                     -- ^ use lower of all reserve formulas
-                   deriving (Show, Eq, Generic)
+                   deriving (Show, Eq, Generic, Ord)
 
 data Account = Account {
     accBalance :: Balance                 -- ^ account current balance
@@ -44,7 +44,7 @@ data Account = Account {
     ,accInterest :: Maybe InterestInfo    -- ^ account reinvestment interest
     ,accType :: Maybe ReserveAmount       -- ^ target info if a reserve account
     ,accStmt :: Maybe Statement           -- ^ transactional history
-} deriving (Show, Generic)
+} deriving (Show, Generic,Eq, Ord)
 
 -- | build interest earn actions
 buildEarnIntAction :: [Account] -> Date -> [(String,Dates)] -> [(String,Dates)]

--- a/src/Asset.hs
+++ b/src/Asset.hs
@@ -101,7 +101,7 @@ data Pool a = Pool {assets :: [a]                                           -- ^
                    ,asOfDate :: Date                                        -- ^ include cashflow after this date 
                    ,issuanceStat :: Maybe (Map.Map CutoffFields Balance)    -- ^ cutoff balance of pool
                    ,extendPeriods :: Maybe DatePattern                      -- ^ dates for extend pool collection
-                   } deriving (Show,Generic)
+                   } deriving (Show,Generic,Ord,Eq)
 
 poolFutureCf :: Asset a => Lens' (Pool a) (Maybe CF.CashFlowFrame)
 poolFutureCf = lens getter setter 

--- a/src/Asset.hs
+++ b/src/Asset.hs
@@ -9,7 +9,7 @@ module Asset (Pool(..),aggPool
        ,buildAssumptionPpyDefRecRate,buildAssumptionPpyDelinqDefRecRate
        ,calcRecoveriesFromDefault
        ,priceAsset,applyHaircut,buildPrepayRates,buildDefaultRates
-       ,poolFutureCf,issuanceStat,assets,poolFutureTxn
+       ,poolFutureCf,issuanceStat,assets,poolFutureTxn,poolIssuanceStat
 ) where
 
 import qualified Data.Time as T
@@ -113,12 +113,21 @@ poolFutureTxn :: Asset a => Lens' (Pool a) [CF.TsRow]
 poolFutureTxn = lens getter setter
   where 
     getter p = case futureCf p of
-                 Nothing -> []
+                 Nothing -> []::[CF.TsRow]
                  Just (CF.CashFlowFrame txns) -> txns
     setter p trs = case futureCf p of
                      Nothing -> p {futureCf = Just (CF.CashFlowFrame trs)}
                      Just (CF.CashFlowFrame _) -> p {futureCf = Just (CF.CashFlowFrame trs)}
 
+poolIssuanceStat :: Asset a => Lens' (Pool a) (Map.Map CutoffFields Balance)
+poolIssuanceStat = lens getter setter
+  where 
+    getter p =  case issuanceStat p of
+                  Nothing -> Map.empty
+                  Just m -> m
+    setter p m = case issuanceStat p of
+                    Nothing -> p {issuanceStat = Just m}
+                    Just m -> p {issuanceStat = Just m}
 
 -- | get stats of pool 
 getIssuanceField :: Pool a -> CutoffFields -> Balance

--- a/src/Asset.hs
+++ b/src/Asset.hs
@@ -116,8 +116,8 @@ poolFutureTxn = lens getter setter
                  Nothing -> []
                  Just (CF.CashFlowFrame txns) -> txns
     setter p trs = case futureCf p of
-                     Nothing -> p {futureCf = Just CF.CashFlowFrame trs}
-                     Just (CF.CashFlowFrame _) -> p {futureCf = Just CF.CashFlowFrame trs}
+                     Nothing -> p {futureCf = Just (CF.CashFlowFrame trs)}
+                     Just (CF.CashFlowFrame _) -> p {futureCf = Just (CF.CashFlowFrame trs)}
 
 
 -- | get stats of pool 

--- a/src/Asset.hs
+++ b/src/Asset.hs
@@ -74,8 +74,6 @@ class (Show a,IR.UseRate a) => Asset a where
   getRemainTerms :: a -> Int
   -- | project asset cashflow under credit stress and interest assumptions
   projCashflow :: a -> Date -> A.AssetPerf -> Maybe [RateAssumption] -> (CF.CashFlowFrame, Map.Map CutoffFields Balance)
-  -- | project cashflow under user input sequence
-  runCashflow :: a -> Date -> A.AssumpReceipes -> [RateAssumption] -> (CF.CashFlowFrame, Map.Map CutoffFields Balance)
   -- | Get possible number of borrower 
   getBorrowerNum :: a -> Int
   -- | Split asset per rates passed in 

--- a/src/Asset.hs
+++ b/src/Asset.hs
@@ -9,7 +9,7 @@ module Asset (Pool(..),aggPool
        ,buildAssumptionPpyDefRecRate,buildAssumptionPpyDelinqDefRecRate
        ,calcRecoveriesFromDefault
        ,priceAsset,applyHaircut,buildPrepayRates,buildDefaultRates
-       ,poolFutureCf,issuanceStat,assets,poolFutureTxn,poolIssuanceStat
+       ,poolFutureCf,poolFutureTxn,poolIssuanceStat
 ) where
 
 import qualified Data.Time as T
@@ -122,9 +122,7 @@ poolFutureTxn = lens getter setter
 poolIssuanceStat :: Asset a => Lens' (Pool a) (Map.Map CutoffFields Balance)
 poolIssuanceStat = lens getter setter
   where 
-    getter p =  case issuanceStat p of
-                  Nothing -> Map.empty
-                  Just m -> m
+    getter p =  fromMaybe Map.empty $ issuanceStat p
     setter p m = case issuanceStat p of
                     Nothing -> p {issuanceStat = Just m}
                     Just m -> p {issuanceStat = Just m}

--- a/src/AssetClass/AssetBase.hs
+++ b/src/AssetClass/AssetBase.hs
@@ -29,13 +29,13 @@ data AmortPlan = Level                   -- ^ for mortgage / french system  -> f
                | I_P                     -- ^ interest only and principal due at last payment
                | F_P                     -- ^ fee based 
                | ScheduleRepayment Ts (Maybe DatePattern)   -- ^ custom principal follow
-               deriving (Show,Generic)
+               deriving (Show,Generic,Ord,Eq)
 
 data Status = Current
             | Defaulted (Maybe Date)
             -- | Delinquency (Maybe Int)
             -- | Extended (Maybe T.Day)
-            deriving (Show,Generic)
+            deriving (Show,Generic,Ord,Eq)
 
 data PrepayPenaltyType = ByTerm Int Rate Rate           -- ^ using penalty rate 1 if period < Int, use penalty rate 2 if period > Int
                        | FixAmount Balance (Maybe Int)  -- ^ fixed penalty fee if any prepayment, or it only applies if period < Int
@@ -43,7 +43,7 @@ data PrepayPenaltyType = ByTerm Int Rate Rate           -- ^ using penalty rate 
                        | Sliding Rate Rate              -- ^ starting with Rate1 at period 1 then decrease by step by rate2
                        | StepDown [(Int,Rate)]          -- ^ first tuple (n,r) ,first n periods use penalty rate r , then next n periods use pentaly rate in next tuple
                        -- | NMonthInterest Int
-                       deriving (Show,Generic)
+                       deriving (Show,Generic,Eq,Ord)
 
 data AmortRule = DecliningBalance        -- ^ DecliningBalance Method
                | DoubleDecliningBalance  -- ^ Not implemented
@@ -51,7 +51,7 @@ data AmortRule = DecliningBalance        -- ^ DecliningBalance Method
                -- | UnitBased Int
                -- | MACRS
                | SumYearsDigit           -- ^ Not implemented
-               deriving (Show,Generic)
+               deriving (Show,Generic,Eq,Ord)
 
 data OriginalInfo = MortgageOriginalInfo { originBalance :: Balance
                                           ,originRate :: IR.RateType
@@ -78,56 +78,56 @@ data OriginalInfo = MortgageOriginalInfo { originBalance :: Balance
                                      ,accRule :: AmortRule
                                      ,capacity :: Capacity 
                                     }
-                  deriving (Show,Generic)
+                  deriving (Show,Generic,Ord,Eq)
 
 
 data Installment = Installment OriginalInfo Balance RemainTerms Status
                  | Dummy
-                 deriving (Show,Generic)
+                 deriving (Show,Generic,Ord,Eq)
 
 data LeaseStepUp = FlatRate DatePattern Rate
                  | ByRateCurve DatePattern [Rate]
-                 deriving (Show,Generic)
+                 deriving (Show,Generic,Ord,Eq)
 
 data Lease = RegularLease OriginalInfo Balance RemainTerms Status
            | StepUpLease OriginalInfo LeaseStepUp Balance RemainTerms Status
-           deriving (Show,Generic)
+           deriving (Show,Generic,Eq,Ord)
 
 data AccrualPeriod = AccrualPeriod Date DailyRate
-                    deriving (Show,Generic)
+                    deriving (Show,Generic,Eq,Ord)
 
 instance TimeSeries AccrualPeriod where 
     getDate (AccrualPeriod d _) = d
 
 data Loan = PersonalLoan OriginalInfo Balance IRate RemainTerms Status
           | DUMMY
-          deriving (Show,Generic)
+          deriving (Show,Generic,Ord,Eq)
 
 data Mortgage = Mortgage OriginalInfo Balance IRate RemainTerms (Maybe BorrowerNum) Status
               | AdjustRateMortgage OriginalInfo IR.ARM Balance IRate RemainTerms (Maybe BorrowerNum) Status
               | ScheduleMortgageFlow Date [CF.TsRow] DatePattern
-              deriving (Show,Generic)
+              deriving (Show,Generic,Eq,Ord)
 
 data MixedAsset = MixedPool (Map.Map String [AssetUnion])
                 | DUMMY2
-                deriving (Show,Generic)
+                deriving (Show,Generic,Eq,Ord)
 
 -- FixedAsset 
 data Capacity = FixedCapacity Balance
               | CapacityByTerm [(Int,Balance)]
-              deriving (Show,Generic)
+              deriving (Show,Generic,Ord,Eq)
 
 data AssociateExp = ExpPerPeriod Balance 
                   | ExpPerUnit Balance
-                  deriving (Show,Generic)
+                  deriving (Show,Generic,Ord,Eq)
 
 data AssociateIncome = IncomePerPeriod Balance 
                      | IncomePerUnit Balance
-                      deriving (Show,Generic)
+                      deriving (Show,Generic,Ord,Eq)
 
 data FixedAsset = FixedAsset OriginalInfo RemainTerms
                 | Dummy5
-                deriving (Show,Generic)
+                deriving (Show,Generic,Eq,Ord)
 
 
 -- Base type to hold all asset types
@@ -136,7 +136,7 @@ data AssetUnion = MO Mortgage
                 | IL Installment
                 | LS Lease
                 | FA FixedAsset
-                deriving (Show, Generic)
+                deriving (Show, Generic,Ord,Eq)
 
 instance IR.UseRate MixedAsset where
   getIndexes (MixedPool ma) = error "Not implemented"

--- a/src/AssetClass/AssetBase.hs
+++ b/src/AssetClass/AssetBase.hs
@@ -138,8 +138,12 @@ data AssetUnion = MO Mortgage
                 | FA FixedAsset
                 deriving (Show, Generic,Ord,Eq)
 
-instance IR.UseRate MixedAsset where
-  getIndexes (MixedPool ma) = error "Not implemented"
+instance IR.UseRate AssetUnion where
+  getIndex (MO ma) = IR.getIndex ma
+  getIndex (LO ma) = IR.getIndex ma
+  getIndex (IL ma) = IR.getIndex ma
+  getIndex (LS ma) = IR.getIndex ma
+  getIndex (FA ma) = IR.getIndex ma
 
 
 instance IR.UseRate Mortgage where 
@@ -150,11 +154,11 @@ instance IR.UseRate Mortgage where
 
 instance IR.UseRate Loan where
   getIndex (PersonalLoan oi@LoanOriginalInfo{originRate = IR.Floater _ idx _ _ _ _ _ _ } _ _ _ _) = Just idx 
-  getIndex (PersonalLoan {}) = Nothing
+  getIndex PersonalLoan {} = Nothing
 
 instance IR.UseRate Installment where 
   getIndex (Installment oi@LoanOriginalInfo{originRate = IR.Floater _ idx _ _ _ _ _ _ } _ _ _) = Just idx 
-  getIndex (Installment {}) = Nothing
+  getIndex Installment {} = Nothing
   
 instance IR.UseRate Lease where
   getIndex :: Lease -> Maybe Index

--- a/src/AssetClass/Loan.hs
+++ b/src/AssetClass/Loan.hs
@@ -172,5 +172,7 @@ instance Asset Loan where
   projCashflow m@(PersonalLoan (LoanOriginalInfo ob or ot p sd prinPayType) cb cr rt (Defaulted Nothing)) asOfDay assumps _
     = (CF.CashFlowFrame [CF.LoanFlow asOfDay 0 0 0 0 0 0 0 cr Nothing],Map.empty)
   
+  projCashflow a b c d = error $ "failed to match projCashflow"++show a++show b++show c++show d
+  
   splitWith l@(PersonalLoan (LoanOriginalInfo ob or ot p sd prinPayType) cb cr rt st) rs
     = [ PersonalLoan (LoanOriginalInfo (mulBR ob ratio) or ot p sd prinPayType) (mulBR cb ratio) cr rt st | ratio <- rs ]

--- a/src/AssetClass/MixedAsset.hs
+++ b/src/AssetClass/MixedAsset.hs
@@ -39,17 +39,121 @@ import qualified Asset as Ast
 
 
 
-instance P.Asset MixedAsset where
+instance P.Asset AssetUnion where
 
-  getCurrentBal ma = 0
-
-  getOriginBal ma = 0
-
-  getOriginRate ma = 0
-
-  calcCashflow pl asOfDay mRates 
-    = CF.CashFlowFrame []
+  calcCashflow ma asOfDay mRates = error "not implemented for asset union"
   
+  getCurrentBal ma = curBal ma
+
+  getOriginBal ma = origBal ma
+
+  getOriginRate ma = origRate ma
+
+  getOriginDate ma = origDate ma
+  
+  getOriginInfo ma = origInfo ma
+  
+  isDefaulted = isDefault
+  
+  getPaymentDates ma n = getPaydates ma n
+
+  getRemainTerms = remainTerms
+
+  projCashflow ma asOfDay assumps mRates = projAssetUnion ma asOfDay assumps mRates
+  
+  getBorrowerNum = borrowerNum 
+
+  splitWith = splitWith
+
+  updateOriginDate = updateOrigDate
+  
+  calcAlignDate = calcAlignDate
+  
+curBal:: ACM.AssetUnion -> Balance
+curBal (ACM.MO ast) = P.getCurrentBal ast
+curBal (ACM.LO ast) = P.getCurrentBal ast
+curBal (ACM.IL ast) = P.getCurrentBal ast
+curBal (ACM.LS ast) = P.getCurrentBal ast
+curBal (ACM.FA ast) = P.getCurrentBal ast
+
+origBal :: ACM.AssetUnion -> Balance
+origBal (ACM.MO ast) = P.getOriginBal ast
+origBal (ACM.LO ast) = P.getOriginBal ast
+origBal (ACM.IL ast) = P.getOriginBal ast
+origBal (ACM.LS ast) = P.getOriginBal ast
+origBal (ACM.FA ast) = P.getOriginBal ast
+
+origRate :: ACM.AssetUnion -> IRate
+origRate (ACM.MO ast) = P.getOriginRate ast
+origRate (ACM.LO ast) = P.getOriginRate ast
+origRate (ACM.IL ast) = P.getOriginRate ast
+origRate (ACM.LS ast) = P.getOriginRate ast
+origRate (ACM.FA ast) = P.getOriginRate ast
+
+origDate :: ACM.AssetUnion -> Date
+origDate (ACM.MO ast) = P.getOriginDate ast
+origDate (ACM.LO ast) = P.getOriginDate ast
+origDate (ACM.IL ast) = P.getOriginDate ast
+origDate (ACM.LS ast) = P.getOriginDate ast
+origDate (ACM.FA ast) = P.getOriginDate ast
+ 
+origInfo :: ACM.AssetUnion -> OriginalInfo
+origInfo (ACM.MO ast) = P.getOriginInfo ast
+origInfo (ACM.LO ast) = P.getOriginInfo ast
+origInfo (ACM.IL ast) = P.getOriginInfo ast
+origInfo (ACM.LS ast) = P.getOriginInfo ast
+origInfo (ACM.FA ast) = P.getOriginInfo ast
+
+isDefault :: ACM.AssetUnion -> Bool 
+isDefault (ACM.MO ast) = P.isDefaulted ast
+isDefault (ACM.LO ast) = P.isDefaulted ast
+isDefault (ACM.IL ast) = P.isDefaulted ast
+isDefault (ACM.LS ast) = P.isDefaulted ast
+isDefault (ACM.FA ast) = P.isDefaulted ast
+
+getPaydates :: ACM.AssetUnion -> Int -> [Date]
+getPaydates (ACM.MO ast) n = P.getPaymentDates ast n 
+getPaydates (ACM.LO ast) n = P.getPaymentDates ast n 
+getPaydates (ACM.IL ast) n = P.getPaymentDates ast n 
+getPaydates (ACM.LS ast) n = P.getPaymentDates ast n 
+getPaydates (ACM.FA ast) n = P.getPaymentDates ast n
+
+remainTerms :: ACM.AssetUnion -> Int
+remainTerms (ACM.MO ast) = P.getRemainTerms ast
+remainTerms (ACM.LO ast) = P.getRemainTerms ast
+remainTerms (ACM.IL ast) = P.getRemainTerms ast
+remainTerms (ACM.LS ast) = P.getRemainTerms ast
+remainTerms (ACM.FA ast) = P.getRemainTerms ast
+
+borrowerNum :: ACM.AssetUnion -> Int
+borrowerNum (ACM.MO ast) = P.getBorrowerNum ast
+borrowerNum (ACM.LO ast) = P.getBorrowerNum ast
+borrowerNum (ACM.IL ast) = P.getBorrowerNum ast
+borrowerNum (ACM.LS ast) = P.getBorrowerNum ast
+borrowerNum (ACM.FA ast) = P.getBorrowerNum ast
+
+splitWith :: ACM.AssetUnion -> [Rate] -> [ACM.AssetUnion]
+splitWith (ACM.MO ast) rs = ACM.MO <$> P.splitWith ast rs
+splitWith (ACM.LO ast) rs = ACM.LO <$> P.splitWith ast rs 
+splitWith (ACM.IL ast) rs = ACM.IL <$> P.splitWith ast rs
+splitWith (ACM.LS ast) rs = ACM.LS <$> P.splitWith ast rs
+splitWith (ACM.FA ast) rs = ACM.FA <$> P.splitWith ast rs
+
+updateOrigDate :: ACM.AssetUnion -> Date -> ACM.AssetUnion
+updateOrigDate (ACM.MO ast) d = ACM.MO $ P.updateOriginDate ast d 
+updateOrigDate (ACM.LO ast) d = ACM.LO $ P.updateOriginDate ast d 
+updateOrigDate (ACM.IL ast) d = ACM.IL $ P.updateOriginDate ast d 
+updateOrigDate (ACM.LS ast) d = ACM.LS $ P.updateOriginDate ast d 
+updateOrigDate (ACM.FA ast) d = ACM.FA $ P.updateOriginDate ast d
+
+calcAlignDate :: ACM.AssetUnion -> Date -> Date
+calcAlignDate (ACM.MO ast) = P.calcAlignDate ast 
+calcAlignDate (ACM.LO ast) = P.calcAlignDate ast 
+calcAlignDate (ACM.IL ast) = P.calcAlignDate ast 
+calcAlignDate (ACM.LS ast) = P.calcAlignDate ast 
+calcAlignDate (ACM.FA ast) = P.calcAlignDate ast 
+
+
 projAssetUnion :: ACM.AssetUnion -> Date -> A.AssetPerf -> Maybe [RateAssumption] -> (CF.CashFlowFrame, Map.Map CutoffFields Balance)
 projAssetUnion (ACM.MO ast) d assumps mRates = P.projCashflow ast d assumps mRates
 projAssetUnion (ACM.LO ast) d assumps mRates = P.projCashflow ast d assumps mRates

--- a/src/Assumptions.hs
+++ b/src/Assumptions.hs
@@ -56,7 +56,8 @@ data ApplyAssumptionType = PoolLevel AssetPerf
                            -- ^ assumption apply to all assets in the pool
                          | ByIndex [StratPerfByIdx]
                            -- ^ assumption which only apply to a set of assets in the pool
-                         | ByName (Map.Map String AssetPerf)
+                         | ByName (Map.Map PoolId AssetPerf)
+                           -- ^ assumption for a named pool
                          deriving (Show,Generic)
 
 data NonPerfAssumption = NonPerfAssumption {

--- a/src/Call.hs
+++ b/src/Call.hs
@@ -24,6 +24,6 @@ data CallOption = PoolBalance Balance    -- ^ triggered when pool perform balanc
                 | Or [CallOption]        -- ^ triggered when any option is satisfied
                 | PoolPv Balance         -- ^ Call when PV of pool fall below
                 | Pre Pre                -- ^ triggered when pool perform balance below threshold
-                deriving (Show,Generic)
+                deriving (Show,Generic,Ord,Eq)
 
 $(deriveJSON defaultOptions ''CallOption)

--- a/src/Cashflow.hs
+++ b/src/Cashflow.hs
@@ -572,8 +572,8 @@ insertBegTsRow d (CashFlowFrame (txn:txns))
       CashFlowFrame (begRow:txn:txns)
 
 combineCashFlow :: CashFlowFrame -> CashFlowFrame -> CashFlowFrame
-combineCashFlow cf1 (CashFlowFrame txn) 
-  = appendCashFlow cf1 txn
+combineCashFlow cf1 (CashFlowFrame []) = cf1 
+combineCashFlow cf1 (CashFlowFrame txn) = appendCashFlow cf1 txn
 
 totalLoss :: CashFlowFrame -> Balance
 totalLoss (CashFlowFrame rs) = sum $ mflowLoss <$> rs
@@ -723,15 +723,19 @@ extendTxns tr ds = [ emptyTsRow d tr | d <- ds ]
 
 isEmptyRow :: TsRow -> Bool 
 isEmptyRow (MortgageDelinqFlow _ 0 0 0 0 0 0 0 0 _ _ _ _) = True
-isEmptyRow (MortgageDelinqFlow {}) = False
+isEmptyRow MortgageDelinqFlow {} = False
 isEmptyRow (MortgageFlow _ 0 0 0 0 0 0 0 _ _ _ _) = True
-isEmptyRow (MortgageFlow {}) = False
+isEmptyRow MortgageFlow {} = False
 isEmptyRow (LoanFlow _ 0 0 0 0 0 0 0 i j ) = True
-isEmptyRow (LoanFlow {}) = False
+isEmptyRow LoanFlow {} = False
 isEmptyRow (LeaseFlow _ 0 0) = True
-isEmptyRow (LeaseFlow {}) = False
+isEmptyRow LeaseFlow {} = False
 isEmptyRow (FixedFlow _ 0 0 0 0 0) = True
-isEmptyRow (FixedFlow {}) = False
+isEmptyRow FixedFlow {} = False
+isEmptyRow (BondFlow _ 0 0 0) = True
+isEmptyRow BondFlow {} = False
+isEmptyRow (CashFlow _ 0) = True
+isEmptyRow CashFlow {} = False
 
 -- ^ Remove empty cashflow from the tail
 dropTailEmptyTxns :: [TsRow] -> [TsRow]

--- a/src/Cashflow.hs
+++ b/src/Cashflow.hs
@@ -406,6 +406,7 @@ firstDate (CashFlowFrame rs) = getDate $ head rs
 combine :: CashFlowFrame -> CashFlowFrame -> CashFlowFrame 
 combine (CashFlowFrame txn1) (CashFlowFrame txn2) = CashFlowFrame $ combineTss [] txn1 txn2
 
+-- ^ TODO need to make sure it will genreate empty row 
 aggTsByDates :: [TsRow] -> [Date] -> [TsRow]
 aggTsByDates trs ds =
   map 

--- a/src/Cashflow.hs
+++ b/src/Cashflow.hs
@@ -106,7 +106,7 @@ instance TimeSeries TsRow where
 
 data CashFlowFrame = CashFlowFrame [TsRow]
                    | MultiCashFlowFrame (Map.Map String [CashFlowFrame])
-                   deriving (Eq,Generic)
+                   deriving (Eq,Generic,Ord)
 
 instance Show CashFlowFrame where
   show (CashFlowFrame []) = "Empty CashflowFrame"

--- a/src/Cashflow.hs
+++ b/src/Cashflow.hs
@@ -406,7 +406,6 @@ firstDate (CashFlowFrame rs) = getDate $ head rs
 combine :: CashFlowFrame -> CashFlowFrame -> CashFlowFrame 
 combine (CashFlowFrame txn1) (CashFlowFrame txn2) = CashFlowFrame $ combineTss [] txn1 txn2
 
--- ^ TODO need to make sure it will genreate empty row 
 aggTsByDates :: [TsRow] -> [Date] -> [TsRow]
 aggTsByDates trs ds =
   map 

--- a/src/Cashflow.hs
+++ b/src/Cashflow.hs
@@ -413,11 +413,10 @@ aggTsByDates trs ds =
     (\(x,_d) -> sumTsCF x _d) 
     (filter 
       (\(y,__d) -> not (null y))
-      (zip (reduceFn [] ds trs) ds)) -- `debug` ("Final agg >> "++ show (reduceFn [] ds trs) )
+      (zip (reduceFn [] ds trs) ds)) 
   where
-    reduceFn accum _ [] =  accum  -- `debug` ("Returning->"++show(accum))
+    reduceFn accum _ [] =  accum  
     reduceFn accum [cutoffDay] _trs =
-      -- accum ++ [(filter (\x -> getDate x <= cutoffDay) _trs)]
       accum ++ [cutBy Inc Past cutoffDay _trs]
     reduceFn accum (cutoffDay:cutoffDays) _trs =
       case newAcc of

--- a/src/CreditEnhancement.hs
+++ b/src/CreditEnhancement.hs
@@ -32,7 +32,7 @@ data LiqSupportType = ReplenishSupport DatePattern Balance    -- ^ credit will b
                     | FixSupport Balance                      -- ^ fixed credit amount
                     | ByPct DealStats Rate                    -- ^ By a pct of formula
                     | UnLimit                                 -- ^ Unlimit credit support, like insurance company
-                    deriving(Show,Generic)
+                    deriving(Show,Generic,Eq,Ord)
 
 data LiqFacility = LiqFacility {
     liqName :: String 
@@ -53,7 +53,7 @@ data LiqFacility = LiqFacility {
     ,liqStart :: Date                        -- ^ when liquidiy provider came into effective
     ,liqEnds :: Maybe Date                   -- ^ when liquidiy provider came into expired
     ,liqStmt :: Maybe Statement              -- ^ transaction history
-} deriving (Show,Generic)
+} deriving (Show,Generic,Eq,Ord)
 
 
 buildLiqResetAction :: [LiqFacility] -> Date -> [(String, Dates)] -> [(String, Dates)]
@@ -96,13 +96,13 @@ data LiqDrawType = LiqToAcc        -- ^ draw credit and deposit cash to account
                  | LiqToBondInt    -- ^ draw credit and pay to bond interest if any shortfall
                  | LiqToBondPrin   -- ^ draw credit and pay to bond principal if any shortfall
                  | LiqToFee        -- ^ draw credit and pay to a fee if there is a shortfall
-                 deriving (Show,Generic)
+                 deriving (Show,Generic,Ord,Eq)
 
 data LiqRepayType = LiqBal         -- ^ repay oustanding balance of liquidation provider
                   | LiqPremium     -- ^ repay oustanding premium fee of lp
                   | LiqInt         -- ^ repay oustanding interest of lp
                   | LiqRepayTypes [LiqRepayType] --TODO not implemented
-                  deriving (Show,Generic)
+                  deriving (Show,Generic,Ord,Eq)
 
 repay :: Amount -> Date -> LiqRepayType -> LiqFacility -> LiqFacility
 repay amt d pt liq@LiqFacility{liqBalance = liqBal

--- a/src/Deal.hs
+++ b/src/Deal.hs
@@ -722,7 +722,7 @@ getInits t@TestDeal{fees=feeMap,pool=thePool,status=status,bonds=bndMap} mAssump
              (MultiPool pm, Just (AP.ByName assumpMap))
                -> Map.mapWithKey 
                     (\k p -> P.aggPool(P.issuanceStat p) $ 
-                               runPool p (AP.PoolLevel <$> (Map.lookup k assumpMap)) (AP.interest =<< mNonPerfAssump))
+                               runPool p (AP.PoolLevel <$> Map.lookup k assumpMap) (AP.interest =<< mNonPerfAssump))
                     pm
              (MultiPool pm,_) 
                -> Map.map (\p -> P.aggPool(P.issuanceStat p) $ runPool p mAssumps (AP.interest =<< mNonPerfAssump)) pm
@@ -734,7 +734,7 @@ getInits t@TestDeal{fees=feeMap,pool=thePool,status=status,bonds=bndMap} mAssump
     poolAggCfM = Map.map (\x -> CF.aggTsByDates x (getDates pActionDates)) poolCfTsM
     begRowM = Map.map (\x -> (buildBegTsRow startDate . head) x:[]) poolAggCfM
     -- pCollectionCfAfterCutoff = CF.CashFlowFrame $ begRow:poolAggCf
-    pCollectionCfAfterCutoff = Map.map CF.CashFlowFrame $  Map.unionWith (\a b -> a++b) begRowM poolAggCfM
+    pCollectionCfAfterCutoff = Map.map CF.CashFlowFrame $  Map.unionWith (++) begRowM poolAggCfM
     -- if preclosing deal , issuance balance is using beg balance of projected cashflow
     -- if it is ongoing deal, issuance balance is user input ( deal is not aware of issuance balance as point of time)
     -- issuanceBalance = case status t of

--- a/src/Deal/DealAction.hs
+++ b/src/Deal/DealAction.hs
@@ -270,7 +270,7 @@ calcDueInt t calc_date mBal mRate b@(L.Bond bn bt bo bi _ bond_bal bond_rate _ i
                        _ -> DC_ACT_365F
                 overrideBal = maybe bond_bal (queryDeal t ) mBal
                 overrideRate = maybe bond_rate (queryDealRate t) mRate
-                newDueInt = IR.calcInt (overrideBal+intDue) int_due_date calc_date overrideRate dc  -- `debug` ("Bond bal"++show bond_bal++">>"++show int_due_date++">>"++ show calc_date++">>"++show bond_rate)
+                newDueInt = IR.calcInt (overrideBal+intDue) int_due_date calc_date overrideRate dc -- `debug` ("Using Rate"++show overrideRate++">>Bal"++ show overrideBal)
 
 
 calcDuePrin :: P.Asset a => TestDeal a -> T.Day -> L.Bond -> L.Bond
@@ -838,7 +838,7 @@ performAction d t@TestDeal{fees=feeMap} (W.CalcFee fns)
 performAction d t@TestDeal{bonds=bndMap} (W.CalcBondInt bns mBalDs mRateDs) 
   = t {bonds = Map.union newBondMap bndMap}
   where 
-    newBondMap = Map.map (calcDueInt t d Nothing Nothing) $ getBondByName t (Just bns)
+    newBondMap = Map.map (calcDueInt t d mBalDs mRateDs) $ getBondByName t (Just bns)
 
 performAction d t@TestDeal{accounts=accs, liqProvider = Just _liqProvider} (W.LiqSupport limit pName CE.LiqToAcc an)
   = t { accounts = newAccMap, liqProvider = Just newLiqMap } -- `debug` ("Using LImit"++ show limit)

--- a/src/Deal/DealBase.hs
+++ b/src/Deal/DealBase.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Deal.DealBase (TestDeal(..),SPV(..),dealBonds,dealFees,dealAccounts,dealPool,PoolType(..),getIssuanceStats
                      ,getAllAsset,getAllAssetList,getAllCollectedFrame,getLatestCollectFrame,getAllCollectedTxns

--- a/src/Deal/DealBase.hs
+++ b/src/Deal/DealBase.hs
@@ -46,6 +46,7 @@ import Control.Lens.TH
 import Data.IntMap (filterWithKey)
 import qualified Data.Text as T
 import Text.Read (readMaybe)
+import Asset (poolFutureCf)
 
 
 class SPV a where
@@ -60,7 +61,7 @@ class SPV a where
 data PoolType a = SoloPool (P.Pool a)
                 | MultiPool (Map.Map PoolId (P.Pool a))
                 | ResecDeal (Map.Map (BondName, Rate) (TestDeal a))
-                deriving (Show,Generic)
+                deriving (Generic,Eq,Show,Ord)
 
 
 data TestDeal a = TestDeal { name :: String
@@ -81,7 +82,7 @@ data TestDeal a = TestDeal { name :: String
                              ,triggers :: Maybe (Map.Map DealCycle (Map.Map String Trigger))
                              ,overrides :: Maybe [OverrideType]
                              ,ledgers :: Maybe (Map.Map String LD.Ledger)
-                           } deriving (Show,Generic)
+                           } deriving (Show,Generic,Eq,Ord)
 
 instance SPV (TestDeal a) where
   getBondByName t bns

--- a/src/Deal/DealBase.hs
+++ b/src/Deal/DealBase.hs
@@ -3,7 +3,9 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE LambdaCase #-}
 
-module Deal.DealBase (TestDeal(..),SPV(..),dealBonds,dealFees,dealAccounts,dealPool) 
+module Deal.DealBase (TestDeal(..),SPV(..),dealBonds,dealFees,dealAccounts,dealPool,PoolType(..),getIssuanceStats
+                     ,getAllAsset,getAllAssetList,getAllCollectedFrame,getLatestCollectFrame,getAllCollectedTxns
+                     ,getIssuanceStatsConsol,getAllCollectedTxnsList,getPoolsByName) 
   where
 import qualified Accounts as A
 import qualified Ledger as LD
@@ -31,6 +33,7 @@ import qualified Data.Set as S
 import Data.List
 import Data.Fixed
 import Data.Maybe
+import Data.Ratio
 import Data.Aeson hiding (json)
 import qualified Data.Aeson.Encode.Pretty as Pretty
 import Language.Haskell.TH
@@ -39,6 +42,9 @@ import Data.Aeson.Types
 import GHC.Generics
 import Control.Lens hiding (element)
 import Control.Lens.TH
+import Data.IntMap (filterWithKey)
+import qualified Data.Text as T
+import Text.Read (readMaybe)
 
 
 class SPV a where
@@ -47,14 +53,22 @@ class SPV a where
   getBondStmtByName :: a -> Maybe [String] -> Map.Map String (Maybe Statement)
   getFeeByName :: a -> Maybe [String] -> Map.Map String F.Fee
   getAccountByName :: a -> Maybe [String] -> Map.Map String A.Account
-  
+
+
+
+data PoolType a = SoloPool (P.Pool a)
+                | MultiPool (Map.Map PoolId (P.Pool a))
+                | ResecDeal (Map.Map (BondName, Rate) (TestDeal a))
+                deriving (Show,Generic)
+
+
 data TestDeal a = TestDeal { name :: String
                              ,status :: DealStatus
                              ,dates :: DateDesp
                              ,accounts :: Map.Map AccountName A.Account
                              ,fees :: Map.Map FeeName F.Fee
                              ,bonds :: Map.Map BondName L.Bond
-                             ,pool ::  P.Pool a 
+                             ,pool ::  PoolType a 
                              ,waterfall :: Map.Map W.ActionWhen W.DistributionSeq
                              ,collects :: [W.CollectionRule]
                              ,call :: Maybe [C.CallOption]
@@ -114,12 +128,66 @@ dealFees = lens getter setter
     getter d = fees d 
     setter d newFeeMap = d {fees = newFeeMap}
 
-dealPool :: P.Asset a => Lens' (TestDeal a) (P.Pool a)
+dealPool :: P.Asset a => Lens' (TestDeal a) (PoolType a)
 dealPool = lens getter setter 
   where 
     getter d = pool d
     setter d newPool = d {pool = newPool}
 
+-- ^ get issuance pool stat from pool map
+getIssuanceStats :: P.Asset a => TestDeal a  -> Maybe [PoolId] -> Map.Map PoolId (Map.Map CutoffFields Balance)
+getIssuanceStats t@TestDeal{pool = pt} mPoolId
+  = let 
+      selectedPools = getPoolsByName t mPoolId 
+    in
+      Map.map (fromMaybe Map.empty . P.issuanceStat) selectedPools
 
+getIssuanceStatsConsol :: P.Asset a => TestDeal a -> Maybe [PoolId] -> Map.Map CutoffFields Balance
+getIssuanceStatsConsol t mPns 
+  = let 
+      ms = getIssuanceStats t mPns
+    in 
+      Map.unionsWith (+) $ Map.elems ms
 
+getAllAsset :: P.Asset a => TestDeal a -> Maybe [PoolId] -> Map.Map PoolId [a]
+getAllAsset t@TestDeal{pool = pt} mPns = 
+  let 
+    assetMap = case pt of 
+                 SoloPool p -> Map.fromList [(PoolConsol, P.assets p)]
+                 MultiPool pm -> Map.map P.assets pm
+  in
+    case mPns of 
+      Nothing -> assetMap 
+      Just pns -> Map.filterWithKey (\k _ -> k `elem` pns ) assetMap
+    
+getAllAssetList :: P.Asset a => TestDeal a -> [a]
+getAllAssetList t = concat $ Map.elems (getAllAsset t Nothing)
+
+getPoolsByName :: P.Asset a => TestDeal a -> Maybe [PoolId] -> Map.Map PoolId (P.Pool a)
+getPoolsByName TestDeal{pool = pt} Nothing = 
+  case pt of 
+    SoloPool p -> Map.fromList [(PoolConsol,p)]
+    MultiPool pm -> pm
+getPoolsByName TestDeal{pool = pt} (Just pNames) =
+  case pt of
+    SoloPool _ -> error $ "Can't lookup"++ show pNames ++"In a Solo Pool deal"
+    MultiPool pm -> Map.filterWithKey (\k _ -> k `elem` pNames) pm
+
+getAllCollectedFrame :: P.Asset a => TestDeal a -> Maybe [PoolId] -> Map.Map PoolId (Maybe CF.CashFlowFrame)
+getAllCollectedFrame t@TestDeal{pool = pt} mPns = Map.map P.futureCf $ getPoolsByName t mPns 
+
+getLatestCollectFrame :: P.Asset a => TestDeal a -> Maybe [PoolId] -> Map.Map PoolId (Maybe CF.TsRow)
+getLatestCollectFrame t mPns = Map.map (last . view CF.cashflowTxn <$>) (getAllCollectedFrame t mPns)
+
+getAllCollectedTxns :: P.Asset a => TestDeal a -> Maybe [PoolId] -> Map.Map PoolId (Maybe [CF.TsRow])
+getAllCollectedTxns t mPns = Map.map (view CF.cashflowTxn <$>) (getAllCollectedFrame t mPns)
+
+getAllCollectedTxnsList :: P.Asset a => TestDeal a -> Maybe [PoolId] -> [CF.TsRow]
+getAllCollectedTxnsList t mPns 
+  = concat $ fromMaybe [] <$>  listOfTxns
+    where 
+      listOfTxns = Map.elems $ getAllCollectedTxns t mPns
+                                
+
+$(deriveJSON defaultOptions ''PoolType)
 $(deriveJSON defaultOptions ''TestDeal)

--- a/src/Deal/DealQuery.hs
+++ b/src/Deal/DealQuery.hs
@@ -39,8 +39,8 @@ debug = flip trace
 
 -- | calcuate target balance for a reserve account, 0 for a non-reserve account
 calcTargetAmount :: P.Asset a => TestDeal a -> Date -> A.Account -> Balance
-calcTargetAmount t d (A.Account _ n i Nothing _ ) = 0
-calcTargetAmount t d (A.Account _ n i (Just r) _ ) =
+calcTargetAmount t d (A.Account _ _ _ Nothing _ ) = 0
+calcTargetAmount t d (A.Account _ _ _ (Just r) _ ) =
    eval r 
    where
      eval ra = case ra of

--- a/src/Deal/DealQuery.hs
+++ b/src/Deal/DealQuery.hs
@@ -142,6 +142,8 @@ queryDealRate t s =
       FloorWith s floor -> toRational $ max (queryDealRate t s) (queryDealRate t floor)
       FloorWithZero s -> toRational $ max (queryDealRate t s) 0
       CapWith s cap -> toRational $ min (queryDealRate t s) (queryDealRate t cap)
+      Factor s r -> toRational $ (queryDealRate t s) * fromRational r
+      
 
 queryDealInt :: P.Asset a => TestDeal a -> DealStats -> Date -> Int 
 queryDealInt t@TestDeal{ pool = p ,bonds = bndMap } s d = 

--- a/src/Deal/DealQuery.hs
+++ b/src/Deal/DealQuery.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Deal.DealQuery (queryDealBool,queryDeal,queryDealInt,queryDealRate
                        ,patchDateToStats, testPre, calcTargetAmount) 
@@ -32,6 +33,8 @@ import Control.Lens hiding (element)
 import Control.Lens.TH
 import Debug.Trace
 import Cashflow (CashFlowFrame(CashFlowFrame))
+import qualified Cashflow as P
+import qualified Util as CF
 debug = flip trace
 
 -- | calcuate target balance for a reserve account, 0 for a non-reserve account
@@ -54,8 +57,8 @@ calcTargetAmount t d (A.Account _ n i (Just r) _ ) =
 patchDateToStats :: Date -> DealStats -> DealStats
 patchDateToStats d t
    = case t of
-         CurrentPoolBalance -> FutureCurrentPoolBalance
-         PoolFactor -> FutureCurrentPoolFactor d
+         CurrentPoolBalance mPns -> FutureCurrentPoolBalance mPns
+         PoolFactor mPns -> FutureCurrentPoolFactor d mPns
          LastBondIntPaid bns -> BondsIntPaidAt d bns
          LastFeePaid fns -> FeesPaidAt d fns
          LastBondPrinPaid bns -> BondsPrinPaidAt d bns
@@ -68,7 +71,7 @@ patchDateToStats d t
          Max dss -> Max $ [ patchDateToStats d ds | ds <- dss ]
          Factor _ds r -> Factor (patchDateToStats d _ds) r
          UseCustomData n -> CustomData n d
-         CurrentPoolBorrowerNum -> FutureCurrentPoolBorrowerNum d
+         CurrentPoolBorrowerNum mPns -> FutureCurrentPoolBorrowerNum d mPns
          FeeTxnAmt ns mCmt -> FeeTxnAmtBy d ns mCmt
          BondTxnAmt ns mCmt -> BondTxnAmtBy d ns mCmt
          AccTxnAmt ns mCmt -> AccTxnAmtBy d ns mCmt
@@ -82,26 +85,26 @@ queryDealRate t s =
       BondFactor ->
         toRational (queryDeal t CurrentBondBalance) / toRational (queryDeal t OriginalBondBalance)
 
-      PoolFactor ->
-        toRational (queryDeal t CurrentPoolBalance)  / toRational (queryDeal t OriginalPoolBalance)
+      PoolFactor mPns ->
+        toRational (queryDeal t (CurrentPoolBalance mPns))  / toRational (queryDeal t (OriginalPoolBalance mPns))
 
-      FutureCurrentPoolFactor asOfDay ->
-        toRational (queryDeal t FutureCurrentPoolBalance) / toRational (queryDeal t OriginalPoolBalance)
+      FutureCurrentPoolFactor asOfDay mPns ->
+        toRational (queryDeal t (FutureCurrentPoolBalance mPns)) / toRational (queryDeal t (OriginalPoolBalance mPns))
       
-      CumulativePoolDefaultedRate ->
+      CumulativePoolDefaultedRate mPns ->
         let 
-          originPoolBal = toRational (queryDeal t OriginalPoolBalance) -- `debug` ("A")-- `debug` (">>Pool Bal"++show (queryDeal t OriginalPoolBalance))
-          cumuPoolDefBal = toRational (queryDeal t CumulativePoolDefaultedBalance) -- `debug` ("B") -- `debug` (">>CUMU"++show (queryDeal t CumulativePoolDefaultedBalance))
+          originPoolBal = toRational $ queryDeal t (OriginalPoolBalance mPns) -- `debug` ("A")-- `debug` (">>Pool Bal"++show (queryDeal t OriginalPoolBalance))
+          cumuPoolDefBal = toRational $ queryDeal t (CumulativePoolDefaultedBalance mPns) -- `debug` ("B") -- `debug` (">>CUMU"++show (queryDeal t CumulativePoolDefaultedBalance))
         in 
           cumuPoolDefBal / originPoolBal -- `debug` ("cumulative p def rate"++show cumuPoolDefBal++">>"++show originPoolBal)
       
-      CumulativeNetLossRatio ->
-        toRational $ (queryDeal t CumulativeNetLoss) / (queryDeal t OriginalPoolBalance)
+      CumulativeNetLossRatio mPns ->
+        toRational $ queryDeal t (CumulativeNetLoss mPns) / queryDeal t (OriginalPoolBalance mPns)
 
-      CumulativePoolDefaultedRateTill idx -> 
+      CumulativePoolDefaultedRateTill idx mPns -> 
         let 
-          originPoolBal = toRational (queryDeal t OriginalPoolBalance) -- `debug` ("A")-- `debug` (">>Pool Bal"++show (queryDeal t OriginalPoolBalance))
-          cumuPoolDefBal = toRational (queryDeal t (PoolCumCollectionTill idx [NewDefaults])) -- `debug` ("B") -- `debug` (">>CUMU"++show (queryDeal t CumulativePoolDefaultedBalance))
+          originPoolBal = toRational (queryDeal t (OriginalPoolBalance mPns)) -- `debug` ("A")-- `debug` (">>Pool Bal"++show (queryDeal t OriginalPoolBalance))
+          cumuPoolDefBal = toRational (queryDeal t (PoolCumCollectionTill idx [NewDefaults] mPns)) -- `debug` ("B") -- `debug` (">>CUMU"++show (queryDeal t CumulativePoolDefaultedBalance))
         in 
           cumuPoolDefBal / originPoolBal -- `debug` ("cumulative p def rate"++show cumuPoolDefBal++">>"++show originPoolBal)
         
@@ -116,11 +119,13 @@ queryDealRate t s =
         in 
           toRational $ sum (zipWith (+) ws rs) / sum ws
 
-      PoolWaRate -> 
-        toRational $ 
-          case P.futureCf (pool t) of 
-            Nothing -> 0
-            Just (CF.CashFlowFrame trs) -> CF.mflowRate $ last trs
+      PoolWaRate mPns -> 
+        let 
+          latestCfs = filter isJust $ Map.elems $ getLatestCollectFrame t mPns
+          rates = toRational <$> maybe 0.0 CF.mflowRate  <$> latestCfs
+          bals = maybe 0.0 CF.mflowBalance  <$> latestCfs
+        in 
+          weightedBy bals rates
 
       Constant r -> r
       Max ss -> toRational $ maximum' [ queryDealRate t s | s <- ss ]
@@ -141,14 +146,18 @@ queryDealRate t s =
 queryDealInt :: P.Asset a => TestDeal a -> DealStats -> Date -> Int 
 queryDealInt t@TestDeal{ pool = p ,bonds = bndMap } s d = 
   case s of 
-    FutureCurrentPoolBorrowerNum d ->
-      case P.futureCf (pool t) of 
-        Nothing -> 0
-        Just (CF.CashFlowFrame trs) -> 
-            let 
-              (_cf,_) = splitByDate trs d EqToLeft
-            in 
-              fromMaybe 0 $ CF.mflowBorrowerNum $ last _cf
+    FutureCurrentPoolBorrowerNum d mPns ->   --TODO may use date as cutoff date 
+      let 
+        poolCfs = Map.elems $ getLatestCollectFrame t mPns
+        poolBn =  maybe 0 (\x -> fromMaybe 0 (CF.mflowBorrowerNum x))   <$> poolCfs
+      in 
+        sum poolBn
+
+    CurrentPoolBorrowerNum mPns ->
+      let 
+        assetM = getAllAssetList t 
+      in 
+        sum $ P.getBorrowerNum <$> assetM -- `debug` ("Qurey loan level asset balance"        
 
     MonthsTillMaturity bn -> 
         case mm of 
@@ -157,7 +166,7 @@ queryDealInt t@TestDeal{ pool = p ,bonds = bndMap } s d =
         where
             (L.Bond _ _ (L.OriginalInfo _ _ _ mm) _ _ _ _ _ _ _ _ _ _) = bndMap Map.! bn  
 
-    ProjCollectPeriodNum -> length $ maybe [] CF.getTsCashFlowFrame $ view P.poolFutureCf p -- `debug` ("Hit query")
+    ProjCollectPeriodNum -> maximum' $ Map.elems $ Map.map (maybe 0 CF.sizeCashFlowFrame) $ getAllCollectedFrame t Nothing
 
     FloorAndCap floor cap s -> max (queryDealInt t floor d) $ min (queryDealInt t cap d ) (queryDealInt t s d)
     FloorWith s floor -> max (queryDealInt t s d) (queryDealInt t floor d)
@@ -167,6 +176,7 @@ queryDealInt t@TestDeal{ pool = p ,bonds = bndMap } s d =
     Max ss -> maximum' $ [ queryDealInt t s d | s <- ss ]
     Min ss -> minimum' $ [ queryDealInt t s d | s <- ss ]
 
+-- ^ map from Pool Source to Pool CutoffFields in Pool Map
 poolSourceToIssuanceField :: PoolSource -> CutoffFields
 poolSourceToIssuanceField CollectedInterest = HistoryInterest
 poolSourceToIssuanceField CollectedPrincipal = HistoryPrincipal
@@ -178,30 +188,31 @@ poolSourceToIssuanceField a = error ("Failed to match pool source when mapping t
 
 
 queryDeal :: P.Asset a => TestDeal a -> DealStats -> Balance
-queryDeal t@TestDeal{accounts=accMap, bonds=bndMap, fees=feeMap, ledgers=ledgerM, pool=poolM} s = 
+queryDeal t@TestDeal{accounts=accMap, bonds=bndMap, fees=feeMap, ledgers=ledgerM, pool=pt } s = 
   case s of
     CurrentBondBalance ->
       Map.foldr (\x acc -> L.bndBalance x + acc) 0.0 bndMap
     OriginalBondBalance ->
       Map.foldr (\x acc -> L.originBalance (L.bndOriginInfo x) + acc) 0.0 bndMap
-    CurrentPoolBalance ->
-      foldl (\acc x -> acc + P.getCurrentBal x) 0.0 (P.assets (pool t)) -- `debug` ("Qurey loan level asset balance")
+    CurrentPoolBalance mPns ->
+      foldl (\acc x -> acc + P.getCurrentBal x) 0.0 (getAllAssetList t) --TODO TOBE FIX: mPns is not used
     CurrentPoolDefaultedBalance ->
       foldl (\acc x -> acc + P.getCurrentBal x)
             0.0 $
-            filter P.isDefaulted (P.assets (pool t))
+            filter P.isDefaulted (getAllAssetList t)
 
-    OriginalPoolBalance ->
-      case P.issuanceStat (pool t) of
-        -- use issuance balance from map if the map exists
-        Just m -> 
-          case Map.lookup IssuanceBalance m of 
-            Just v -> v
-            Nothing -> error "No issuance balance found in the pool, pls specify it in the pool stats map `issuanceStat`"
-        Nothing -> error ("No stat found in the pool, pls specify it in the pool stats map `issuanceStat` Deal:" ++ show (name t))
+    DealIssuanceBalance mPns -> 
+      sum $ Map.findWithDefault 0.0 IssuanceBalance <$> Map.elems (getIssuanceStats t mPns)
+
+    OriginalPoolBalance _ -> error "Not implemented"
+      -- case P.issuanceStat (pool t) of
+      --   -- use issuance balance from map if the map exists
+      --   Just m -> 
+      --     case Map.lookup IssuanceBalance m of 
+      --       Just v -> v
+      --       Nothing -> error "No issuance balance found in the pool, pls specify it in the pool stats map `issuanceStat`"
+      --   Nothing -> error ("No stat found in the pool, pls specify it in the pool stats map `issuanceStat` Deal:" ++ show (name t))
     
-    CurrentPoolBorrowerNum ->
-      fromRational $ toRational $ foldl (\acc x -> acc + P.getBorrowerNum x) 0 (P.assets (pool t)) -- `debug` ("Qurey loan level asset balance")
  
     AllAccBalance -> sum $ map A.accBalance $ Map.elems accMap 
     
@@ -215,24 +226,27 @@ queryDeal t@TestDeal{accounts=accMap, bonds=bndMap, fees=feeMap, ledgers=ledgerM
     ReserveExcessAt d ans ->
       max 
         0
-        $ (-) (queryDeal t (AccBalance ans)) (sum $ (calcTargetAmount t d) <$> ((accMap Map.!) <$> ans))
+        $ (-) (queryDeal t (AccBalance ans)) (sum $ calcTargetAmount t d <$> ((accMap Map.!) <$> ans))
 
     ReserveAccGapAt d ans ->
       max 
         0 
-        $ (-) (sum $ (calcTargetAmount t d) <$> (accMap Map.!) <$> ans ) (queryDeal t (AccBalance ans)) 
+        $ (-) (sum $ calcTargetAmount t d <$> (accMap Map.!) <$> ans ) (queryDeal t (AccBalance ans)) 
 
-    FutureCurrentPoolBalance ->
-       case P.futureCf (pool t) of 
-         Nothing -> 0.0
-         Just (CF.CashFlowFrame trs) -> CF.mflowBalance $ last trs
+    FutureCurrentPoolBalance mPns ->
+      let 
+        ltc = getLatestCollectFrame t mPns
+      in 
+        sum $ maybe 0 CF.mflowBalance <$> ltc
+
     
-    FutureCurrentPoolBegBalance ->
-       case P.futureCf (pool t) of 
-         Nothing -> 0.0
-         Just (CF.CashFlowFrame trs) -> CF.mflowBegBalance $ last trs
+    FutureCurrentPoolBegBalance mPns ->
+      let 
+        ltc = getLatestCollectFrame t mPns
+      in 
+        sum $ maybe 0 CF.mflowBegBalance <$> ltc 
 
-    PoolCollectionHistory incomeType fromDay asOfDay ->
+    PoolCollectionHistory incomeType fromDay asOfDay mPns ->
       sum fieldAmts
       where
         fieldAmts = map
@@ -241,88 +255,84 @@ queryDeal t@TestDeal{accounts=accMap, bonds=bndMap, fees=feeMap, ledgers=ledgerM
                         CollectedPrincipal -> CF.mflowPrincipal 
                         CollectedPrepayment -> CF.mflowPrepayment
                         CollectedRecoveries -> CF.mflowRecovery
-                        CollectedPrepaymentPenalty -> CF.mflowPrepaymentPenalty)
+                        CollectedPrepaymentPenalty -> CF.mflowPrepaymentPenalty
+                        CollectedCash  -> CF.tsTotalCash
+                        -- TODO add cash here
+                        )
                       subflow  
-        subflow = case P.futureCf (pool t) of
-                    -- Just _futureCf -> 
-                    Just (CashFlowFrame trs) -> 
-                        if fromDay == asOfDay then 
-                          sliceBy II fromDay asOfDay trs
-                        else 
-                          sliceBy EI fromDay asOfDay trs
-                    _ -> []
+        mTxns = Map.elems $ getAllCollectedTxns t mPns
+        subflow = sliceBy EI fromDay asOfDay $ concat $ fromMaybe [] <$> mTxns
 
-    CumulativePoolDefaultedBalance ->
+    CumulativePoolDefaultedBalance mPns ->
         let
-          futureDefaults = case P.futureCf poolM of
-                             Just (CF.CashFlowFrame historyTxn) -> CF.tsCumDefaultBal $ last historyTxn
-                             Nothing -> 0.0  -- `debug` ("Geting future defaults"++show futureDefaults)
-
-          historyDefaults = case P.issuanceStat poolM of
-                                Just m -> Map.findWithDefault 0.0 HistoryDefaults m 
-                                Nothing -> 0.0
+          latestCollect = getLatestCollectFrame t mPns
+          futureDefaults = sum $ Map.elems $ Map.map (maybe 0 CF.tsCumDefaultBal) $ latestCollect 
+          historyStat = getIssuanceStats t mPns
+          historyDefaults = sum $ Map.findWithDefault 0 HistoryDefaults <$> Map.elems historyStat
         in
           futureDefaults + historyDefaults -- `debug` ("history defaults"++ show historyDefaults)
 
-    CumulativePoolRecoveriesBalance ->
-        let 
-          futureRecoveries = case P.futureCf poolM of
-                               Just (CF.CashFlowFrame historyTxn) -> CF.tsCumRecoveriesBal $ last historyTxn
-                               Nothing -> 0.0
-          historyRecoveries = case P.issuanceStat poolM of
-                                Just m -> Map.findWithDefault 0.0 HistoryRecoveries m 
-                                Nothing -> 0.0
+    CumulativePoolRecoveriesBalance mPns ->
+        let
+          latestCollect = getLatestCollectFrame t mPns
+          futureRecoveries = sum $ Map.elems $ Map.map (maybe 0 CF.tsCumRecoveriesBal) $ latestCollect 
+          historyStat = getIssuanceStats t mPns
+          historyRecoveries = sum $ Map.findWithDefault 0 HistoryRecoveries <$> Map.elems historyStat
         in
           futureRecoveries + historyRecoveries
     
-    CumulativeNetLoss ->
-         queryDeal t CumulativePoolDefaultedBalance - queryDeal t CumulativePoolRecoveriesBalance
+    CumulativeNetLoss mPns ->
+         queryDeal t (CumulativePoolDefaultedBalance mPns) - queryDeal t (CumulativePoolRecoveriesBalance mPns)
     
-    PoolCumCollection ps ->
+    PoolCumCollection ps mPns ->
         let 
-          futureVals = case P.futureCf poolM of
-                         Just cf -> sum $ CF.sumPoolFlow cf <$> ps
-                         Nothing -> 0.0
-
-          historyVals = case P.issuanceStat poolM of
-                                Just m -> sum [ Map.findWithDefault 0.0 (poolSourceToIssuanceField p) m | p <- ps ]
-                                Nothing -> 0.0
+          collectedTxns = concat . Map.elems $ Map.map (fromMaybe []) $ getAllCollectedTxns t mPns
+          --xxx = sum (  <$> ps ) <*> collectedFrames
+          --mBals = (\cf -> sum (fromMaybe [] cf) <$> ps ) <$> collectedFrames
+          futureVals = sum $ (CF.lookupSource <$> collectedTxns) <*> ps
+          
+          poolStats = Map.elems $ getIssuanceStats t mPns
+          historyVals = sum $ (Map.findWithDefault 0.0 . poolSourceToIssuanceField <$> ps) <*> poolStats
+          -- historyVals = case P.issuanceStat poolM of
+          --                       Just m -> sum [ Map.findWithDefault 0.0 (poolSourceToIssuanceField p) m | p <- ps ]
+          --                       Nothing -> 0.0
         in 
           futureVals + historyVals
     
-    PoolCumCollectionTill idx ps -> 
+    PoolCumCollectionTill idx ps mPns -> 
         let 
-          futureVals = case P.futureCf poolM of
-                         Just (CashFlowFrame _trs) -> 
-                          let 
-                            lengthTrs = length _trs
-                            trs = slice 0 (max 0 (lengthTrs + idx)) _trs
-                          in 
-                            sum $ (CF.lookupSource <$> trs) <*> ps
-                         Nothing -> 0.0
-
-          historyVals = case P.issuanceStat poolM of
-                                Just m -> sum [ Map.findWithDefault 0.0 (poolSourceToIssuanceField p) m | p <- ps ]
-                                Nothing -> 0.0
+          txnMap = Map.map (dropLastN (negate idx) . fromMaybe []) $ getAllCollectedTxns t mPns 
+          txnList = concat $ Map.elems txnMap 
+          lookupList = CF.lookupSource <$> txnList
+          futureVals = sum $ lookupList <*> ps
+          sumMap = getIssuanceStatsConsol t mPns
+          historyVals = sum $ Map.findWithDefault 0 . poolSourceToIssuanceField <$> ps <*> [sumMap]
         in 
           futureVals + historyVals
  
-    PoolCurCollection ps ->
-      case P.futureCf poolM of
-            Just (CF.CashFlowFrame trs) -> sum $ CF.lookupSource (last trs) <$> ps
-            Nothing -> 0.0
+    PoolCurCollection ps mPns ->
+      let 
+        pCf = getLatestCollectFrame t mPns
+        lastRows = Map.map (maybe 0 (\r -> sum (CF.lookupSource r <$> ps))) pCf
+      in 
+        sum $ Map.elems lastRows
 
-    PoolCollectionStats idx ps -> 
-      case P.futureCf poolM of
-            Just (CF.CashFlowFrame trs) 
-              ->let
-                  theCollection = trs!!((length trs) + idx)
-                in  
-                  sum $ CF.lookupSource theCollection <$> ps
-            Nothing -> 0.0
+    PoolCollectionStats idx ps mPns -> 
+      let 
+        pTxns::[[CF.TsRow]] = fromMaybe [] <$> (view CF.cashflowTxn <$>) <$> Map.elems (getAllCollectedFrame t mPns)
+        pRows = (\x -> x!!(length x + idx) ) <$>  pTxns
+      in 
+        sum $ CF.lookupSource <$> pRows <*> ps
+      -- case P.futureCf poolM of
+      --       Just (CF.CashFlowFrame trs) 
+      --         ->let
+      --             theCollection = trs!!(length trs + idx)
+      --           in  
+      --             sum $ CF.lookupSource theCollection <$> ps
+      --       Nothing -> 0.0
 
 
-    CurrentBondBalanceOf bns -> sum $ L.bndBalance <$> (bndMap Map.!) <$> bns
+    CurrentBondBalanceOf bns -> sum $ L.bndBalance . (bndMap Map.!) <$> bns
 
     BondsIntPaidAt d bns ->
        let

--- a/src/Deal/DealValidation.hs
+++ b/src/Deal/DealValidation.hs
@@ -62,7 +62,7 @@ validateAction ((W.PayFeeResidual _ accName feeName):as) rs accKeys bndKeys feeK
     = validateAction as (rs ++ [ErrorMsg (feeName ++ " not in "++ show feeKeys++" Or "++accName++ " not in "++show accKeys)]) accKeys bndKeys feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys
   | otherwise = validateAction as rs accKeys bndKeys feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys
 
-validateAction ((W.CalcBondInt bnds):as) rs accKeys bndKeys feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys
+validateAction ((W.CalcBondInt bnds Nothing Nothing):as) rs accKeys bndKeys feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys
   | not (Set.isSubsetOf (Set.fromList bnds) bndKeys)
     = validateAction as (rs ++ [ErrorMsg (show bnds ++ " not in "++ show bndKeys)]) accKeys bndKeys feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys
   | otherwise = validateAction as rs accKeys bndKeys feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys

--- a/src/Deal/DealValidation.hs
+++ b/src/Deal/DealValidation.hs
@@ -185,12 +185,12 @@ extractRequiredRates t@TestDeal{accounts = accM
                   Nothing -> []
         
       -- note fee is not tested
-
+-- TODO Need to fix 
 validateAggRule :: [W.CollectionRule] -> [ResultComponent]
 validateAggRule rules = 
-    [ ErrorMsg ("Pool source "++show ps++" has a weight of "++show r)   | (ps,r) <- Map.toList oustandingPs ]
+    [] -- [ ErrorMsg ("Pool source "++show ps++" has a weight of "++show r)   | (ps,r) <- Map.toList oustandingPs ]
   where 
-    countWeight (W.Collect _ ps _) =  Map.fromList [(ps,1.0)]
+    countWeight (W.Collect Nothing ps _) =  Map.fromList [(ps,1.0)]
     countWeight (W.CollectByPct _ ps lst) = Map.fromList [(ps, sum (fst <$> lst))]
     sumMap = foldl1 (Map.unionWith (+)) $ countWeight <$> rules 
     oustandingPs = Map.filter (> 1.0) sumMap

--- a/src/Deal/DealValidation.hs
+++ b/src/Deal/DealValidation.hs
@@ -29,6 +29,7 @@ import qualified InterestRate as IR
 
 import Data.Maybe
 import qualified Assumptions as A
+import Asset (getIssuanceField)
 
 isPreClosing :: TestDeal a -> Bool
 isPreClosing t@TestDeal{ status = PreClosing _ } = True
@@ -158,7 +159,7 @@ validateAction ((W.ActionWithPre2 p subActionList1 subActionList2):as) rs accKey
 validateAction (action:as) rs accKeys bndKeys feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys
   = validateAction as rs accKeys bndKeys feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys
 
-extractRequiredRates :: IR.UseRate a => TestDeal a -> Set.Set Index
+extractRequiredRates :: (P.Asset a,IR.UseRate a) => TestDeal a -> Set.Set Index
 extractRequiredRates t@TestDeal{accounts = accM 
                                ,fees = feeM 
                                ,bonds = bondM 
@@ -169,7 +170,7 @@ extractRequiredRates t@TestDeal{accounts = accM
   = Set.fromList $ assetIndex ++ accIndex ++ bondIndex ++ liqProviderIndex ++ rsIndex ++ rcIndex
   -- = Set.fromList $ accIndex ++ bondIndex ++ liqProviderIndex ++ rsIndex
     where 
-      assetIndex = catMaybes $ IR.getIndex <$> P.assets pool 
+      assetIndex = catMaybes $ IR.getIndex <$> getAllAssetList t
       
       accIndex = catMaybes $ IR.getIndex <$> Map.elems accM 
       bondIndex = concat $ catMaybes $ IR.getIndexes <$> Map.elems bondM 
@@ -195,7 +196,7 @@ validateAggRule rules =
     oustandingPs = Map.filter (> 1.0) sumMap
 
 
-validateReq :: IR.UseRate a => TestDeal a -> AP.NonPerfAssumption -> (Bool,[ResultComponent])
+validateReq :: (IR.UseRate a,P.Asset a) => TestDeal a -> AP.NonPerfAssumption -> (Bool,[ResultComponent])
 validateReq t assump@A.NonPerfAssumption{A.interest = intM} 
   = let 
       ratesRequired = extractRequiredRates t
@@ -214,7 +215,7 @@ validateReq t assump@A.NonPerfAssumption{A.interest = intM}
     in 
       (null finalErrors,finalErrors++finalWarnings)
 
-validatePreRun :: TestDeal a -> ([ResultComponent],[ResultComponent])
+validatePreRun :: P.Asset a => TestDeal a -> ([ResultComponent],[ResultComponent])
 validatePreRun t@TestDeal{waterfall=waterfallM
                       ,accounts =accM 
                       ,fees = feeM 
@@ -241,9 +242,14 @@ validatePreRun t@TestDeal{waterfall=waterfallM
       -- date check
 
       -- issuance balance check 
-      issuanceBalCheck CurrentDates {} = case Map.lookup IssuanceBalance <$> P.issuanceStat pool of
-                                           Nothing -> [ErrorMsg "Issuance balance not found for a Ongoing Deal"]
-                                           Just _ -> []
+      issuanceBalCheck CurrentDates {} = let 
+                                           stats = Map.elems $ getIssuanceStats t Nothing
+                                           lookupResult = Map.lookup IssuanceBalance <$> stats
+                                         in
+                                           if all isNothing lookupResult then
+                                             [ErrorMsg "Issuance balance not found for a Ongoing Deal"]
+                                           else
+                                             []
       issuanceBalCheck _ = []
 
       -- collection rule check
@@ -259,7 +265,8 @@ validatePreRun t@TestDeal{waterfall=waterfallM
 
       allErrors = errors ++ issuanceBalCheck dates ++ aggRuleResult
       -- check issuance balance 
-      w1 = if (not (isPreClosing t)) && (isJust (P.issuanceStat pool)) then
+      
+      w1 = if (not (isPreClosing t)) && (length (Map.elems (getIssuanceStats t Nothing))) == 0 then
              [WarningMsg "Deal passes PreClosing status, but not cumulative defaults/delinq at cutoff date?"]
            else 
              []

--- a/src/Deal/DealValidation.hs
+++ b/src/Deal/DealValidation.hs
@@ -92,7 +92,7 @@ validateAction ((W.PayPrinResidual accName bnds):as) rs accKeys bndKeys feeKeys 
     = validateAction as (rs ++ [ErrorMsg (show bnds++ " not in "++ show bndKeys++" Or "++accName++" not in "++show accKeys)]) accKeys bndKeys feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys
   | otherwise = validateAction as rs accKeys bndKeys feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys
 
-validateAction ((W.BuyAsset _ _ accName):as) rs accKeys bndKeys feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys
+validateAction ((W.BuyAsset _ _ accName _):as) rs accKeys bndKeys feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys
   | Set.notMember accName accKeys = validateAction as (rs ++ [ErrorMsg (accName++" not in "++show accKeys)]) accKeys bndKeys feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys
   | otherwise = validateAction as rs accKeys bndKeys feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys
 
@@ -190,8 +190,8 @@ validateAggRule :: [W.CollectionRule] -> [ResultComponent]
 validateAggRule rules = 
     [ ErrorMsg ("Pool source "++show ps++" has a weight of "++show r)   | (ps,r) <- Map.toList oustandingPs ]
   where 
-    countWeight (W.Collect ps _) =  Map.fromList [(ps,1.0)]
-    countWeight (W.CollectByPct ps lst) = Map.fromList [(ps, sum (fst <$> lst))]
+    countWeight (W.Collect _ ps _) =  Map.fromList [(ps,1.0)]
+    countWeight (W.CollectByPct _ ps lst) = Map.fromList [(ps, sum (fst <$> lst))]
     sumMap = foldl1 (Map.unionWith (+)) $ countWeight <$> rules 
     oustandingPs = Map.filter (> 1.0) sumMap
 

--- a/src/Expense.hs
+++ b/src/Expense.hs
@@ -42,7 +42,7 @@ data FeeType = AnnualRateFee DealStats FormulaRate                       -- ^ an
              | TargetBalanceFee DealStats DealStats                      -- ^ fee occur if (ds1 > ds2)
              | FeeFlow Ts                                                -- ^ a time series based fee 
              | ByCollectPeriod Amount                                    -- ^ fix amount per collection period
-             deriving (Show,Eq, Generic)
+             deriving (Show,Eq, Generic,Ord)
 
 data Fee = Fee {
   feeName :: String              -- ^ fee name
@@ -53,7 +53,7 @@ data Fee = Fee {
   ,feeArrears :: Balance         -- ^ reserved
   ,feeLastPaidDay :: Maybe Date  -- ^ last paid date
   ,feeStmt :: Maybe Statement    -- ^ transaction history
-} deriving (Show,Eq, Generic)
+} deriving (Show,Ord, Eq, Generic)
 
 payFee :: Date   -- ^ When pay action happen
        -> Amount -- ^ Amount paid to fee

--- a/src/Hedge.hs
+++ b/src/Hedge.hs
@@ -41,12 +41,12 @@ type PayoutAmount = Balance          -- ^ cash to be paid in instrutment
 data RateSwapBase = Fixed Balance    -- ^ a fixed balance as notional base 
                   | Base DealStats   -- ^ a referece as notional base
                   | Schedule Ts      -- ^ a predfiend schedule of notional balance
-                  deriving(Show,Generic,Eq)
+                  deriving(Show,Generic,Eq,Ord)
 
 data RateSwapType = FloatingToFloating Floater Floater    -- ^ Paying Floating rate and receiving Floating Rate
                   | FloatingToFixed  Floater IRate        -- ^ Paying Floating Rate and receiving Fixed Rate
                   | FixedToFloating  IRate Floater        -- ^ Paying Fixed Rate and receiving Floating rate
-                  deriving(Show,Generic,Eq)
+                  deriving(Show,Generic,Eq,Ord)
 
 
 data RateSwap = RateSwap {rsType :: RateSwapType         -- ^ swap type
@@ -60,7 +60,7 @@ data RateSwap = RateSwap {rsType :: RateSwapType         -- ^ swap type
                          ,rsNetCash :: Balance           -- ^ amount to pay/collect
                          ,rsStmt :: Maybe Statement      -- ^ transaction history
                          }
-                         deriving(Show,Generic,Eq)
+                         deriving(Show,Generic,Eq,Ord)
 
 -- updateRefBalance :: Balance -> RateSwap -> RateSwap
 -- updateRefBalance bal rs = rs { rsRefBalance = bal}
@@ -125,7 +125,7 @@ data RateCap = RateCap {
                 ,rcNetCash :: Balance           -- ^ amount to collect
                 ,rcStmt :: Maybe Statement      -- ^ transaction history                
               }
-              deriving(Show,Generic,Eq)
+              deriving(Show,Generic,Eq,Ord)
 
 
 receiveRC :: Date -> RateCap -> RateCap
@@ -146,7 +146,7 @@ instance QueryByComment RateCap where
 
 data CurrencySwap = CurrencySwap {
                     csBalance :: Balance
-                    } deriving (Show,Generic)
+                    } deriving (Show,Generic,Ord,Eq)
 
 instance IR.UseRate RateSwap where 
   getIndexes rs@RateSwap{rsType = rstype}

--- a/src/InterestRate.hs
+++ b/src/InterestRate.hs
@@ -50,7 +50,7 @@ type StartRate = IRate
 
 data RateType = Fix DayCount IRate
               | Floater DayCount Index Spread IRate DatePattern RateFloor RateCap (Maybe (RoundingBy IRate))
-              deriving (Show,Generic)
+              deriving (Show,Generic,Eq,Ord)
 
 getDayCount :: RateType -> DayCount
 getDayCount (Fix dc _) = dc
@@ -59,7 +59,7 @@ getDayCount (Floater dc _ _ _ _ _ _ _ ) = dc
 
 data ARM = ARM InitPeriod InitCap PeriodicCap LifetimeCap RateFloor
          | OtherARM
-         deriving (Show,Generic)
+         deriving (Show,Generic,Eq,Ord)
 
 getRateResetDates :: Date -> Date -> Maybe RateType -> Dates
 getRateResetDates _ _ Nothing = []

--- a/src/Ledger.hs
+++ b/src/Ledger.hs
@@ -29,7 +29,7 @@ data Ledger = Ledger {
     ledgName :: String              -- ^ ledger account name
     ,ledgBalance :: Balance         -- ^ current balance of ledger
     ,ledgStmt :: Maybe Statement    -- ^ ledger transaction history
-} deriving (Show, Generic)
+} deriving (Show, Generic,Ord, Eq)
 
 -- | Book an entry with date,amount and transaction to a ledger
 entryLog :: Amount -> Date -> TxnComment -> Ledger -> Ledger

--- a/src/Liability.hs
+++ b/src/Liability.hs
@@ -52,11 +52,11 @@ data InterestInfo = Floater IRate Index Spread RateReset DayCount (Maybe Floor) 
                   | RefRate IRate DealStats Float RateReset               -- ^ interest rate depends to a formula
                   | CapRate InterestInfo IRate                            -- ^ cap rate 
                   | FloorRate InterestInfo IRate                          -- ^ floor rate
-                  deriving (Show, Eq, Generic)
+                  deriving (Show, Eq, Generic, Ord)
                   
 data StepUp = PassDateSpread Date Spread                   -- ^ add a spread on a date and effective afterwards
             | PassDateLadderSpread Date Spread RateReset   -- ^ add a spread on the date pattern
-            deriving (Show, Eq, Generic)
+            deriving (Show, Eq, Generic, Ord)
 
 -- | test if a bond may changes its interest rate
 isAdjustble :: InterestInfo -> Bool 
@@ -94,7 +94,7 @@ data OriginalInfo = OriginalInfo {
   ,originDate::Date                -- ^ issuance date
   ,originRate::Rate                -- ^ issuance rate of the bond
   ,maturityDate :: Maybe Date      -- ^ optional maturity date
-} deriving (Show, Eq, Generic)
+} deriving (Show, Eq, Generic, Ord)
 
 type PlannedAmorSchedule = Ts
 
@@ -104,7 +104,7 @@ data BondType = Sequential                                 -- ^ Pass through typ
               | Lockout Date                               -- ^ No principal due till date
               | Z                                          -- ^ Z tranche
               | Equity                                     -- ^ Equity type tranche
-              deriving (Show, Eq, Generic)
+              deriving (Show, Eq, Generic, Ord)
 
 data Bond = Bond {
   bndName :: String
@@ -120,7 +120,7 @@ data Bond = Bond {
   ,bndLastIntPay :: Maybe Date         -- ^ last interest pay date
   ,bndLastPrinPay :: Maybe Date        -- ^ last principal pay date
   ,bndStmt :: Maybe S.Statement        -- ^ transaction history
-} deriving (Show, Eq, Generic)
+} deriving (Show, Eq, Generic, Ord)
 
 consolStmt :: Bond -> Bond
 consolStmt b@Bond{bndName = bn, bndStmt = Nothing} = b 

--- a/src/Reports.hs
+++ b/src/Reports.hs
@@ -88,7 +88,7 @@ buildBalanceSheet t@TestDeal{ pool = pool, bonds = bndMap , fees = feeMap , liqP
         --tranches
         
         bndM = [ Item bndName bndBal | (bndName,bndBal) <- Map.toList $ Map.map L.bndBalance (bonds t) ]
-        bndAccPayable = [ Item ("Accured Int:"++bndName) bndAccBal | (bndName,bndAccBal) <- Map.toList (Map.map (L.bndDueInt . (calcDueInt t d)) bndMap)]
+        bndAccPayable = [ Item ("Accured Int:"++bndName) bndAccBal | (bndName,bndAccBal) <- Map.toList (Map.map (L.bndDueInt . (calcDueInt t d Nothing Nothing)) bndMap)]
         feeToPay = [ Item ("Fee Due:"++feeName) feeDueBal | (feeName,feeDueBal) <- Map.toList (Map.map (F.feeDue . (calcDueFee t d)) feeMap)]
         liqProviderToPay = [ Item ("Liquidity Provider:"++liqName) liqBal | (liqName,liqBal) <- Map.toList (Map.map (CE.liqBalance . (CE.accrueLiqProvider d)) (fromMaybe Map.empty liqMap))] 
         swapToPay = [ Item ("Swap:"++rsName) (negate rsNet) | (rsName,rsNet) <- Map.toList (Map.map (HE.rsNetCash . (HE.accrueIRS d)) (fromMaybe Map.empty rsMap))

--- a/src/Stmt.hs
+++ b/src/Stmt.hs
@@ -121,7 +121,7 @@ weightAvgBalance sd ed txns
 
 
 data Statement = Statement [Txn]
-        deriving (Show,Eq,Generic)
+        deriving (Show, Generic, Eq, Ord)
 
 appendStmt :: Maybe Statement -> Txn -> Maybe Statement
 appendStmt (Just stmt@(Statement txns)) txn = Just $ Statement (txns++[txn])

--- a/src/Stmt.hs
+++ b/src/Stmt.hs
@@ -166,7 +166,7 @@ getFlow comment =
       SeqPayFee _ -> Outflow
       PayFeeYield _ -> Outflow
       Transfer _ _ -> Interflow 
-      PoolInflow _ -> Inflow
+      PoolInflow _ _ -> Inflow
       LiquidationProceeds -> Inflow
       LiquidationSupport _ -> Inflow
       LiquidationDraw -> Noneflow

--- a/src/Triggers.hs
+++ b/src/Triggers.hs
@@ -34,14 +34,14 @@ data TriggerEffect = DealStatusTo DealStatus                    -- ^ change deal
                    | BuyAsset AccountName PricingMethod         -- ^ buy asset from the assumption using funds from account
                    | TriggerEffects [TriggerEffect]             -- ^ a combination of effects above
                    | DoNothing                                  -- ^ do nothing
-                   deriving (Show, Eq, Generic)
+                   deriving (Show, Eq, Generic,Ord)
  
 data Trigger = Trigger {
             trgCondition :: Pre                       -- ^ condition to trigger 
             ,trgEffects :: TriggerEffect              -- ^ what happen if it was triggered
             ,trgStatus :: Bool                        -- ^ if it is triggered or not 
             ,trgCurable :: Bool                       -- ^ if it is curable trigger
-            } deriving (Show, Eq, Generic)
+            } deriving (Show, Eq, Generic,Ord)
 
 makeLensesFor [("trgStatus","trgStatusLens") ,("trgEffects","trgEffectsLens") ,("trgCondition","trgConditionLens") ,("trgCurable","trgCurableLens")] ''Trigger
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -139,7 +139,7 @@ data DayCount = DC_30E_360       -- ^ ISMA European 30S/360 Special German Eurob
               | DC_30_360_ISDA   -- ^ IDSA
               | DC_30_360_German -- ^ Gernman
               | DC_30_360_US     -- ^ 30/360 US Municipal , Bond basis
-              deriving (Show,Eq,Generic)
+              deriving (Show,Eq,Generic,Ord)
 
 data DateType = ClosingDate        -- ^ deal closing day
               | CutoffDate         -- ^ after which, the pool cashflow was aggregated to SPV
@@ -153,7 +153,7 @@ data Period = Daily
             | Quarterly 
             | SemiAnnually 
             | Annually
-            deriving (Show,Eq,Generic)
+            deriving (Show,Eq,Generic,Ord)
 
 type DateVector = (Date, DatePattern)
 
@@ -165,7 +165,7 @@ data DateDesp = FixInterval (Map.Map DateType Date) Period Period
               | PreClosingDates Date Date (Maybe Date) Date DateVector DateVector
               --  (last collect,last pay), mRevolving end-date dp1-pool-pay dp2-bond-pay
               | CurrentDates (Date,Date) (Maybe Date) Date DateVector DateVector
-              deriving (Show,Eq, Generic)
+              deriving (Show,Eq, Generic,Ord)
 
 data ActionOnDate = EarnAccInt Date AccName              -- ^ sweep bank account interest
                   | ChangeDealStatusTo Date DealStatus   -- ^ change deal status
@@ -236,7 +236,7 @@ instance FromJSONKey DateType where
   fromJSONKey = genericFromJSONKey opts
 
 data OverrideType = CustomActionOnDates [ActionOnDate]
-                    deriving (Show,Generic)
+                    deriving (Show,Generic,Ord,Eq)
 
 data DealStatus = DealAccelerated (Maybe Date)      -- ^ Deal is accelerated status with optinal accerlerated date
                 | DealDefaulted (Maybe Date)        -- ^ Deal is defaulted status with optinal default date
@@ -287,7 +287,7 @@ data DatePattern = MonthEnd
                  | Exclude DatePattern [DatePattern]
                  | OffsetBy DatePattern Int
                  -- | DayOfWeek Int -- T.DayOfWeek
-                 deriving (Show,Eq, Generic)
+                 deriving (Show,Eq, Generic,Ord)
 
 data Direction = Credit
                | Debit
@@ -571,7 +571,7 @@ data Pre = IfZero DealStats
          | Always Bool
          | Any [Pre]
          | All [Pre]                            -- ^ 
-         deriving (Show,Generic,Eq)
+         deriving (Show,Generic,Eq,Ord)
 
 
 data TsPoint a = TsPoint Date a
@@ -755,7 +755,7 @@ data PricingMethod = BalanceFactor Rate Rate          -- ^ [balance] to be multi
                    | PV IRate IRate                   -- ^ discount factor, recovery pct on default
                    | PVCurve Ts                       -- ^ [CF] Pricing cashflow with a Curve
                    | Custom Rate                      -- ^ custom amount
-                   deriving (Show, Eq ,Generic)
+                   deriving (Show, Eq ,Generic,Ord)
 
 type Valuation = Centi
 type PerFace = Micro

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -406,7 +406,7 @@ data PoolId = PoolName String
             deriving (Eq,Ord,Generic)
 
 instance Show PoolId where
-  show (PoolName n)  = "PoolName:"++n
+  show (PoolName n)  = n
   show PoolConsol = "PoolConsol"
 
 instance (Read PoolId) where

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -119,6 +119,7 @@ data Index = LPR5Y
             | EURIBOR3M
             | EURIBOR6M
             | EURIBOR12M
+            | BBSW
             | IRPH --  The IRPH (Índice de Referencia de Préstamos Hipotecarios) is a reference index used in Spain to fix the interest rate of mortgage loans
             | SONIA 
             deriving (Show,Eq,Generic,Ord)

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -9,7 +9,7 @@ module Util
     ,replace,paddingDefault, capWith, getTsDates
     ,shiftTsByAmt,calcWeightBalanceByDates, monthsAfter
     ,getPriceValue,maximum',minimum',roundingBy,roundingByM
-    ,floorWith,slice,toPeriodRateByInterval
+    ,floorWith,slice,toPeriodRateByInterval, dropLastN
     -- for debug
     ,zyj
     )
@@ -262,6 +262,9 @@ roundingByM (Just rb) x = roundingBy rb x
 
 slice :: Int -> Int -> [a] -> [a]
 slice from to xs = take (to - from ) (drop from xs)
+
+dropLastN :: Int -> [a] -> [a]
+dropLastN n xs = slice 0 (length xs - n) xs
 
 toPeriodRateByInterval :: Rate -> Int -> Rate
 toPeriodRateByInterval annualRate days

--- a/src/Waterfall.hs
+++ b/src/Waterfall.hs
@@ -66,11 +66,11 @@ data Action = Transfer (Maybe Limit) AccountName AccountName (Maybe TxnComment)
             -- Fee
             | CalcFee [FeeName]                                                            -- ^ calculate fee due amount in the fee names
             | PayFee (Maybe Limit) AccountName [FeeName] (Maybe ExtraSupport)              -- ^ pay fee with cash from account with optional limit or extra support
-            | PayFeeBySeq (Maybe Limit) AccountName [FeeName] (Maybe ExtraSupport)              -- ^ pay fee with cash from account with optional limit or extra support
+            | PayFeeBySeq (Maybe Limit) AccountName [FeeName] (Maybe ExtraSupport)         -- ^ pay fee with cash from account with optional limit or extra support
             | CalcAndPayFee (Maybe Limit) AccountName [FeeName] (Maybe ExtraSupport)       -- ^ combination of CalcFee and PayFee
             | PayFeeResidual (Maybe Limit) AccountName FeeName                             -- ^ pay fee regardless fee due amount
             -- Bond - Interest
-            | CalcBondInt [BondName]                                                       -- ^ calculate interest due amount in the bond names
+            | CalcBondInt [BondName] (Maybe DealStats) (Maybe DealStats)                   -- ^ calculate interest due amount in the bond names,with optional balance and rate
             | PayInt (Maybe Limit) AccountName [BondName] (Maybe ExtraSupport)             -- ^ pay interest with cash from the account with optional limit or extra support
             | PayIntBySeq (Maybe Limit) AccountName [BondName] (Maybe ExtraSupport)        -- ^ with sequence
             | AccrueAndPayInt (Maybe Limit) AccountName [BondName] (Maybe ExtraSupport)    -- ^ combination of CalcInt and PayInt

--- a/src/Waterfall.hs
+++ b/src/Waterfall.hs
@@ -84,7 +84,7 @@ data Action = Transfer (Maybe Limit) AccountName AccountName (Maybe TxnComment)
             | PayIntPrinBySeq (Maybe Limit) AccountName [BondName] (Maybe ExtraSupport)     -- ^ pay int & prin to bonds sequentially
             | AccrueAndPayIntPrinBySeq (Maybe Limit) AccountName [BondName] (Maybe ExtraSupport) 
             -- Pool/Asset change
-            | BuyAsset (Maybe Limit) PricingMethod AccountName                              -- ^ buy asset from revolving assumptions using funds from account
+            | BuyAsset (Maybe Limit) PricingMethod AccountName (Maybe PoolId)               -- ^ buy asset from revolving assumptions using funds from account
             | LiquidatePool PricingMethod AccountName                                       -- ^ sell all assets and deposit proceeds to account
             -- Liquidation support
             | LiqSupport (Maybe Limit) CE.LiquidityProviderName CE.LiqDrawType AccountName  -- ^ draw credit and deposit to account/fee/bond interest/principal

--- a/src/Waterfall.hs
+++ b/src/Waterfall.hs
@@ -54,13 +54,13 @@ instance FromJSONKey ActionWhen where
 data BookType = PDL DealStats [(LedgerName,DealStats)] -- Reverse PDL Debit reference, [(name,cap reference)]
               | ByAccountDraw LedgerName               -- Book amount equal to account draw amount
               | ByDS          LedgerName Direction DealStats     -- Book amount equal to a formula/deal stats
-              deriving (Show,Generic)
+              deriving (Show,Generic,Eq,Ord)
 
 data ExtraSupport = SupportAccount AccountName (Maybe BookType)  -- ^ if there is deficit, draw another account to pay the shortfall
                   | SupportLiqFacility LiquidityProviderName     -- ^ if there is deficit, draw facility's available credit to pay the shortfall
                   | MultiSupport [ExtraSupport]                  -- ^ if there is deficit, draw multiple supports (by sequence in the list) to pay the shortfall
                   | WithCondition Pre ExtraSupport               -- ^ support only available if Pre is true
-                  deriving (Show,Generic)
+                  deriving (Show,Generic,Eq,Ord)
 
 data Action = Transfer (Maybe Limit) AccountName AccountName (Maybe TxnComment)
             -- Fee
@@ -107,13 +107,13 @@ data Action = Transfer (Maybe Limit) AccountName AccountName (Maybe TxnComment)
             | RunTrigger DealCycle TriggerName        -- ^ update the trigger status during the waterfall execution
             -- Debug
             | WatchVal (Maybe String) [DealStats]     -- ^ inspect vals during the waterfall execution
-            deriving (Show,Generic)
+            deriving (Show,Generic,Eq,Ord)
 
 type DistributionSeq = [Action]
 
 data CollectionRule = Collect (Maybe [PoolId]) PoolSource AccountName                   -- ^ collect a pool source from pool collection and deposit to an account
                     | CollectByPct (Maybe [PoolId]) PoolSource [(Rate,AccountName)]     -- ^ collect a pool source from pool collection and deposit to multiple accounts with percentages
-                    deriving (Show,Generic)
+                    deriving (Show,Generic,Eq,Ord)
 
 
 $(deriveJSON defaultOptions ''Action)

--- a/src/Waterfall.hs
+++ b/src/Waterfall.hs
@@ -111,8 +111,8 @@ data Action = Transfer (Maybe Limit) AccountName AccountName (Maybe TxnComment)
 
 type DistributionSeq = [Action]
 
-data CollectionRule = Collect PoolSource AccountName                   -- ^ collect a pool source from pool collection and deposit to an account
-                    | CollectByPct PoolSource [(Rate,AccountName)]     -- ^ collect a pool source from pool collection and deposit to multiple accounts with percentages
+data CollectionRule = Collect (Maybe [PoolId]) PoolSource AccountName                   -- ^ collect a pool source from pool collection and deposit to an account
+                    | CollectByPct (Maybe [PoolId]) PoolSource [(Rate,AccountName)]     -- ^ collect a pool source from pool collection and deposit to multiple accounts with percentages
                     deriving (Show,Generic)
 
 

--- a/swagger.json
+++ b/swagger.json
@@ -1520,7 +1520,7 @@
                         }
                     },
                     "pool": {
-                        "$ref": "#/components/schemas/Pool_Mortgage"
+                        "$ref": "#/components/schemas/PoolType_Mortgage"
                     },
                     "rateCap": {
                         "type": "object",
@@ -1581,6 +1581,92 @@
                     "startDate",
                     "endDate"
                 ]
+            },
+            "PoolType_Installment": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "$ref": "#/components/schemas/Pool_Installment"
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "SoloPool"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "$ref": "#/components/schemas/Pool_Installment"
+                                }
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "MultiPool"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "items": {
+                                    "items": [
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "format": "double",
+                                                    "type": "number"
+                                                }
+                                            ],
+                                            "maxItems": 2,
+                                            "type": "array",
+                                            "minItems": 2
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/TestDeal_Installment"
+                                        }
+                                    ],
+                                    "maxItems": 2,
+                                    "type": "array",
+                                    "minItems": 2
+                                },
+                                "type": "array"
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "ResecDeal"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    }
+                ],
+                "type": "object"
             },
             "AssetUnion": {
                 "oneOf": [
@@ -2004,10 +2090,23 @@
                         "type": "object",
                         "properties": {
                             "contents": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
+                                "items": [
+                                    {
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/DealStats"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/DealStats"
+                                    }
+                                ],
+                                "maxItems": 3,
+                                "type": "array",
+                                "minItems": 3
                             },
                             "tag": {
                                 "type": "string",
@@ -2392,11 +2491,14 @@
                                     },
                                     {
                                         "type": "string"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/PoolId"
                                     }
                                 ],
-                                "maxItems": 3,
+                                "maxItems": 4,
                                 "type": "array",
-                                "minItems": 3
+                                "minItems": 4
                             },
                             "tag": {
                                 "type": "string",
@@ -3767,7 +3869,20 @@
                         "type": "object",
                         "properties": {
                             "contents": {
-                                "$ref": "#/components/schemas/PoolSource"
+                                "items": [
+                                    {
+                                        "items": {
+                                            "$ref": "#/components/schemas/PoolId"
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/PoolSource"
+                                    }
+                                ],
+                                "maxItems": 2,
+                                "type": "array",
+                                "minItems": 2
                             },
                             "tag": {
                                 "type": "string",
@@ -5498,6 +5613,12 @@
                     {
                         "type": "object",
                         "properties": {
+                            "contents": {
+                                "items": {
+                                    "$ref": "#/components/schemas/PoolId"
+                                },
+                                "type": "array"
+                            },
                             "tag": {
                                 "type": "string",
                                 "enum": [
@@ -5506,12 +5627,19 @@
                             }
                         },
                         "required": [
-                            "tag"
+                            "tag",
+                            "contents"
                         ]
                     },
                     {
                         "type": "object",
                         "properties": {
+                            "contents": {
+                                "items": {
+                                    "$ref": "#/components/schemas/PoolId"
+                                },
+                                "type": "array"
+                            },
                             "tag": {
                                 "type": "string",
                                 "enum": [
@@ -5520,7 +5648,8 @@
                             }
                         },
                         "required": [
-                            "tag"
+                            "tag",
+                            "contents"
                         ]
                     },
                     {
@@ -5540,6 +5669,12 @@
                     {
                         "type": "object",
                         "properties": {
+                            "contents": {
+                                "items": {
+                                    "$ref": "#/components/schemas/PoolId"
+                                },
+                                "type": "array"
+                            },
                             "tag": {
                                 "type": "string",
                                 "enum": [
@@ -5548,12 +5683,19 @@
                             }
                         },
                         "required": [
-                            "tag"
+                            "tag",
+                            "contents"
                         ]
                     },
                     {
                         "type": "object",
                         "properties": {
+                            "contents": {
+                                "items": {
+                                    "$ref": "#/components/schemas/PoolId"
+                                },
+                                "type": "array"
+                            },
                             "tag": {
                                 "type": "string",
                                 "enum": [
@@ -5562,12 +5704,19 @@
                             }
                         },
                         "required": [
-                            "tag"
+                            "tag",
+                            "contents"
                         ]
                     },
                     {
                         "type": "object",
                         "properties": {
+                            "contents": {
+                                "items": {
+                                    "$ref": "#/components/schemas/PoolId"
+                                },
+                                "type": "array"
+                            },
                             "tag": {
                                 "type": "string",
                                 "enum": [
@@ -5576,12 +5725,19 @@
                             }
                         },
                         "required": [
-                            "tag"
+                            "tag",
+                            "contents"
                         ]
                     },
                     {
                         "type": "object",
                         "properties": {
+                            "contents": {
+                                "items": {
+                                    "$ref": "#/components/schemas/PoolId"
+                                },
+                                "type": "array"
+                            },
                             "tag": {
                                 "type": "string",
                                 "enum": [
@@ -5590,16 +5746,30 @@
                             }
                         },
                         "required": [
-                            "tag"
+                            "tag",
+                            "contents"
                         ]
                     },
                     {
                         "type": "object",
                         "properties": {
                             "contents": {
-                                "maximum": 9223372036854775807,
-                                "type": "integer",
-                                "minimum": -9223372036854775808
+                                "items": [
+                                    {
+                                        "maximum": 9223372036854775807,
+                                        "type": "integer",
+                                        "minimum": -9223372036854775808
+                                    },
+                                    {
+                                        "items": {
+                                            "$ref": "#/components/schemas/PoolId"
+                                        },
+                                        "type": "array"
+                                    }
+                                ],
+                                "maxItems": 2,
+                                "type": "array",
+                                "minItems": 2
                             },
                             "tag": {
                                 "type": "string",
@@ -5616,6 +5786,12 @@
                     {
                         "type": "object",
                         "properties": {
+                            "contents": {
+                                "items": {
+                                    "$ref": "#/components/schemas/PoolId"
+                                },
+                                "type": "array"
+                            },
                             "tag": {
                                 "type": "string",
                                 "enum": [
@@ -5624,7 +5800,8 @@
                             }
                         },
                         "required": [
-                            "tag"
+                            "tag",
+                            "contents"
                         ]
                     },
                     {
@@ -5644,6 +5821,12 @@
                     {
                         "type": "object",
                         "properties": {
+                            "contents": {
+                                "items": {
+                                    "$ref": "#/components/schemas/PoolId"
+                                },
+                                "type": "array"
+                            },
                             "tag": {
                                 "type": "string",
                                 "enum": [
@@ -5652,12 +5835,40 @@
                             }
                         },
                         "required": [
-                            "tag"
+                            "tag",
+                            "contents"
                         ]
                     },
                     {
                         "type": "object",
                         "properties": {
+                            "contents": {
+                                "items": {
+                                    "$ref": "#/components/schemas/PoolId"
+                                },
+                                "type": "array"
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "DealIssuanceBalance"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "items": {
+                                    "$ref": "#/components/schemas/PoolId"
+                                },
+                                "type": "array"
+                            },
                             "tag": {
                                 "type": "string",
                                 "enum": [
@@ -5666,7 +5877,8 @@
                             }
                         },
                         "required": [
-                            "tag"
+                            "tag",
+                            "contents"
                         ]
                     },
                     {
@@ -5700,6 +5912,12 @@
                     {
                         "type": "object",
                         "properties": {
+                            "contents": {
+                                "items": {
+                                    "$ref": "#/components/schemas/PoolId"
+                                },
+                                "type": "array"
+                            },
                             "tag": {
                                 "type": "string",
                                 "enum": [
@@ -5708,7 +5926,8 @@
                             }
                         },
                         "required": [
-                            "tag"
+                            "tag",
+                            "contents"
                         ]
                     },
                     {
@@ -5754,10 +5973,23 @@
                         "type": "object",
                         "properties": {
                             "contents": {
-                                "items": {
-                                    "$ref": "#/components/schemas/PoolSource"
-                                },
-                                "type": "array"
+                                "items": [
+                                    {
+                                        "items": {
+                                            "$ref": "#/components/schemas/PoolSource"
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "items": {
+                                            "$ref": "#/components/schemas/PoolId"
+                                        },
+                                        "type": "array"
+                                    }
+                                ],
+                                "maxItems": 2,
+                                "type": "array",
+                                "minItems": 2
                             },
                             "tag": {
                                 "type": "string",
@@ -5786,11 +6018,17 @@
                                             "$ref": "#/components/schemas/PoolSource"
                                         },
                                         "type": "array"
+                                    },
+                                    {
+                                        "items": {
+                                            "$ref": "#/components/schemas/PoolId"
+                                        },
+                                        "type": "array"
                                     }
                                 ],
-                                "maxItems": 2,
+                                "maxItems": 3,
                                 "type": "array",
-                                "minItems": 2
+                                "minItems": 3
                             },
                             "tag": {
                                 "type": "string",
@@ -5808,10 +6046,23 @@
                         "type": "object",
                         "properties": {
                             "contents": {
-                                "items": {
-                                    "$ref": "#/components/schemas/PoolSource"
-                                },
-                                "type": "array"
+                                "items": [
+                                    {
+                                        "items": {
+                                            "$ref": "#/components/schemas/PoolSource"
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "items": {
+                                            "$ref": "#/components/schemas/PoolId"
+                                        },
+                                        "type": "array"
+                                    }
+                                ],
+                                "maxItems": 2,
+                                "type": "array",
+                                "minItems": 2
                             },
                             "tag": {
                                 "type": "string",
@@ -5840,11 +6091,17 @@
                                             "$ref": "#/components/schemas/PoolSource"
                                         },
                                         "type": "array"
+                                    },
+                                    {
+                                        "items": {
+                                            "$ref": "#/components/schemas/PoolId"
+                                        },
+                                        "type": "array"
                                     }
                                 ],
-                                "maxItems": 2,
+                                "maxItems": 3,
                                 "type": "array",
-                                "minItems": 2
+                                "minItems": 3
                             },
                             "tag": {
                                 "type": "string",
@@ -6070,6 +6327,12 @@
                     {
                         "type": "object",
                         "properties": {
+                            "contents": {
+                                "items": {
+                                    "$ref": "#/components/schemas/PoolId"
+                                },
+                                "type": "array"
+                            },
                             "tag": {
                                 "type": "string",
                                 "enum": [
@@ -6078,12 +6341,53 @@
                             }
                         },
                         "required": [
-                            "tag"
+                            "tag",
+                            "contents"
                         ]
                     },
                     {
                         "type": "object",
                         "properties": {
+                            "contents": {
+                                "items": [
+                                    {
+                                        "$ref": "#/components/schemas/Day"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/Day"
+                                    },
+                                    {
+                                        "items": {
+                                            "$ref": "#/components/schemas/PoolId"
+                                        },
+                                        "type": "array"
+                                    }
+                                ],
+                                "maxItems": 3,
+                                "type": "array",
+                                "minItems": 3
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "FutureWaCurrentPoolBalance"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "items": {
+                                    "$ref": "#/components/schemas/PoolId"
+                                },
+                                "type": "array"
+                            },
                             "tag": {
                                 "type": "string",
                                 "enum": [
@@ -6092,7 +6396,8 @@
                             }
                         },
                         "required": [
-                            "tag"
+                            "tag",
+                            "contents"
                         ]
                     },
                     {
@@ -6135,7 +6440,20 @@
                         "type": "object",
                         "properties": {
                             "contents": {
-                                "$ref": "#/components/schemas/Day"
+                                "items": [
+                                    {
+                                        "$ref": "#/components/schemas/Day"
+                                    },
+                                    {
+                                        "items": {
+                                            "$ref": "#/components/schemas/PoolId"
+                                        },
+                                        "type": "array"
+                                    }
+                                ],
+                                "maxItems": 2,
+                                "type": "array",
+                                "minItems": 2
                             },
                             "tag": {
                                 "type": "string",
@@ -6153,7 +6471,20 @@
                         "type": "object",
                         "properties": {
                             "contents": {
-                                "$ref": "#/components/schemas/Day"
+                                "items": [
+                                    {
+                                        "$ref": "#/components/schemas/Day"
+                                    },
+                                    {
+                                        "items": {
+                                            "$ref": "#/components/schemas/PoolId"
+                                        },
+                                        "type": "array"
+                                    }
+                                ],
+                                "maxItems": 2,
+                                "type": "array",
+                                "minItems": 2
                             },
                             "tag": {
                                 "type": "string",
@@ -6165,20 +6496,6 @@
                         "required": [
                             "tag",
                             "contents"
-                        ]
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "tag": {
-                                "type": "string",
-                                "enum": [
-                                    "FutureOriginalPoolBalance"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "tag"
                         ]
                     },
                     {
@@ -6896,11 +7213,17 @@
                                     },
                                     {
                                         "$ref": "#/components/schemas/Day"
+                                    },
+                                    {
+                                        "items": {
+                                            "$ref": "#/components/schemas/PoolId"
+                                        },
+                                        "type": "array"
                                     }
                                 ],
-                                "maxItems": 3,
+                                "maxItems": 4,
                                 "type": "array",
-                                "minItems": 3
+                                "minItems": 4
                             },
                             "tag": {
                                 "type": "string",
@@ -7057,6 +7380,12 @@
                     {
                         "type": "object",
                         "properties": {
+                            "contents": {
+                                "items": {
+                                    "$ref": "#/components/schemas/PoolId"
+                                },
+                                "type": "array"
+                            },
                             "tag": {
                                 "type": "string",
                                 "enum": [
@@ -7065,7 +7394,8 @@
                             }
                         },
                         "required": [
-                            "tag"
+                            "tag",
+                            "contents"
                         ]
                     },
                     {
@@ -7191,6 +7521,27 @@
                                 "type": "string",
                                 "enum": [
                                     "Substract"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "items": {
+                                    "$ref": "#/components/schemas/DealStats"
+                                },
+                                "type": "array"
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "Subtract"
                                 ]
                             }
                         },
@@ -7449,6 +7800,92 @@
                 ],
                 "type": "object"
             },
+            "PoolType_Lease": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "$ref": "#/components/schemas/Pool_Lease"
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "SoloPool"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "$ref": "#/components/schemas/Pool_Lease"
+                                }
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "MultiPool"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "items": {
+                                    "items": [
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "format": "double",
+                                                    "type": "number"
+                                                }
+                                            ],
+                                            "maxItems": 2,
+                                            "type": "array",
+                                            "minItems": 2
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/TestDeal_Lease"
+                                        }
+                                    ],
+                                    "maxItems": 2,
+                                    "type": "array",
+                                    "minItems": 2
+                                },
+                                "type": "array"
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "ResecDeal"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    }
+                ],
+                "type": "object"
+            },
             "Ledger": {
                 "type": "object",
                 "properties": {
@@ -7648,6 +8085,92 @@
                                 "type": "string",
                                 "enum": [
                                     "Multiple"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    }
+                ],
+                "type": "object"
+            },
+            "PoolType_FixedAsset": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "$ref": "#/components/schemas/Pool_FixedAsset"
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "SoloPool"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "$ref": "#/components/schemas/Pool_FixedAsset"
+                                }
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "MultiPool"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "items": {
+                                    "items": [
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "format": "double",
+                                                    "type": "number"
+                                                }
+                                            ],
+                                            "maxItems": 2,
+                                            "type": "array",
+                                            "minItems": 2
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/TestDeal_FixedAsset"
+                                        }
+                                    ],
+                                    "maxItems": 2,
+                                    "type": "array",
+                                    "minItems": 2
+                                },
+                                "type": "array"
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "ResecDeal"
                                 ]
                             }
                         },
@@ -7996,7 +8519,7 @@
                         }
                     },
                     "pool": {
-                        "$ref": "#/components/schemas/Pool_Lease"
+                        "$ref": "#/components/schemas/PoolType_Lease"
                     },
                     "rateCap": {
                         "type": "object",
@@ -8220,7 +8743,7 @@
                         }
                     },
                     "pool": {
-                        "$ref": "#/components/schemas/Pool_Installment"
+                        "$ref": "#/components/schemas/PoolType_Installment"
                     },
                     "rateCap": {
                         "type": "object",
@@ -8269,6 +8792,7 @@
                     "EURIBOR3M",
                     "EURIBOR6M",
                     "EURIBOR12M",
+                    "BBSW",
                     "IRPH",
                     "SONIA"
                 ]
@@ -8685,6 +9209,92 @@
                                 "type": "string",
                                 "enum": [
                                     "FDeal"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    }
+                ],
+                "type": "object"
+            },
+            "PoolType_Loan": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "$ref": "#/components/schemas/Pool_Loan"
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "SoloPool"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "$ref": "#/components/schemas/Pool_Loan"
+                                }
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "MultiPool"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "items": {
+                                    "items": [
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "format": "double",
+                                                    "type": "number"
+                                                }
+                                            ],
+                                            "maxItems": 2,
+                                            "type": "array",
+                                            "minItems": 2
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/TestDeal_Loan"
+                                        }
+                                    ],
+                                    "maxItems": 2,
+                                    "type": "array",
+                                    "minItems": 2
+                                },
+                                "type": "array"
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "ResecDeal"
                                 ]
                             }
                         },
@@ -9360,15 +9970,21 @@
                             "contents": {
                                 "items": [
                                     {
+                                        "items": {
+                                            "$ref": "#/components/schemas/PoolId"
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
                                         "$ref": "#/components/schemas/PoolSource"
                                     },
                                     {
                                         "type": "string"
                                     }
                                 ],
-                                "maxItems": 2,
+                                "maxItems": 3,
                                 "type": "array",
-                                "minItems": 2
+                                "minItems": 3
                             },
                             "tag": {
                                 "type": "string",
@@ -9387,6 +10003,12 @@
                         "properties": {
                             "contents": {
                                 "items": [
+                                    {
+                                        "items": {
+                                            "$ref": "#/components/schemas/PoolId"
+                                        },
+                                        "type": "array"
+                                    },
                                     {
                                         "$ref": "#/components/schemas/PoolSource"
                                     },
@@ -9408,9 +10030,9 @@
                                         "type": "array"
                                     }
                                 ],
-                                "maxItems": 2,
+                                "maxItems": 3,
                                 "type": "array",
-                                "minItems": 2
+                                "minItems": 3
                             },
                             "tag": {
                                 "type": "string",
@@ -9556,6 +10178,92 @@
                                 "type": "string",
                                 "enum": [
                                     "AssetCurve"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    }
+                ],
+                "type": "object"
+            },
+            "PoolType_Mortgage": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "$ref": "#/components/schemas/Pool_Mortgage"
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "SoloPool"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "$ref": "#/components/schemas/Pool_Mortgage"
+                                }
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "MultiPool"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "items": {
+                                    "items": [
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "format": "double",
+                                                    "type": "number"
+                                                }
+                                            ],
+                                            "maxItems": 2,
+                                            "type": "array",
+                                            "minItems": 2
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/TestDeal_Mortgage"
+                                        }
+                                    ],
+                                    "maxItems": 2,
+                                    "type": "array",
+                                    "minItems": 2
+                                },
+                                "type": "array"
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "ResecDeal"
                                 ]
                             }
                         },
@@ -9879,10 +10587,54 @@
                 "type": "object"
             },
             "CashFlowFrame": {
-                "items": {
-                    "$ref": "#/components/schemas/TsRow"
-                },
-                "type": "array"
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "items": {
+                                    "$ref": "#/components/schemas/TsRow"
+                                },
+                                "type": "array"
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "CashFlowFrame"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "items": {
+                                        "$ref": "#/components/schemas/CashFlowFrame"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "MultiCashFlowFrame"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    }
+                ],
+                "type": "object"
             },
             "Table_(Fixed_*_E2)_(Fixed_*_E2)": {
                 "items": {
@@ -9964,6 +10716,43 @@
                     "accBalance",
                     "accName"
                 ]
+            },
+            "PoolId": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "type": "string"
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "PoolName"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "PoolConsol"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag"
+                        ]
+                    }
+                ],
+                "type": "object"
             },
             "TsPoint_[AssetUnion]": {
                 "items": [
@@ -10144,7 +10933,7 @@
                         }
                     },
                     "pool": {
-                        "$ref": "#/components/schemas/Pool_Loan"
+                        "$ref": "#/components/schemas/PoolType_Loan"
                     },
                     "rateCap": {
                         "type": "object",
@@ -11348,7 +12137,7 @@
                         }
                     },
                     "pool": {
-                        "$ref": "#/components/schemas/Pool_FixedAsset"
+                        "$ref": "#/components/schemas/PoolType_FixedAsset"
                     },
                     "rateCap": {
                         "type": "object",
@@ -12906,7 +13695,10 @@
                                                 "$ref": "#/components/schemas/DealType"
                                             },
                                             {
-                                                "$ref": "#/components/schemas/CashFlowFrame"
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                    "$ref": "#/components/schemas/CashFlowFrame"
+                                                }
                                             },
                                             {
                                                 "items": {
@@ -12959,7 +13751,10 @@
                                                 "$ref": "#/components/schemas/DealType"
                                             },
                                             {
-                                                "$ref": "#/components/schemas/CashFlowFrame"
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                    "$ref": "#/components/schemas/CashFlowFrame"
+                                                }
                                             },
                                             {
                                                 "items": {
@@ -13010,7 +13805,10 @@
                                             "$ref": "#/components/schemas/DealType"
                                         },
                                         {
-                                            "$ref": "#/components/schemas/CashFlowFrame"
+                                            "type": "object",
+                                            "additionalProperties": {
+                                                "$ref": "#/components/schemas/CashFlowFrame"
+                                            }
                                         },
                                         {
                                             "items": {

--- a/swagger.json
+++ b/swagger.json
@@ -1668,6 +1668,37 @@
                 ],
                 "type": "object"
             },
+            "Pool_AssetUnion": {
+                "type": "object",
+                "properties": {
+                    "issuanceStat": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "multipleOf": 1.0e-2,
+                            "type": "number"
+                        }
+                    },
+                    "asOfDate": {
+                        "$ref": "#/components/schemas/Day"
+                    },
+                    "futureCf": {
+                        "$ref": "#/components/schemas/CashFlowFrame"
+                    },
+                    "extendPeriods": {
+                        "$ref": "#/components/schemas/DatePattern"
+                    },
+                    "assets": {
+                        "items": {
+                            "$ref": "#/components/schemas/AssetUnion"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "assets",
+                    "asOfDate"
+                ]
+            },
             "AssetUnion": {
                 "oneOf": [
                     {
@@ -9216,6 +9247,24 @@
                             "tag",
                             "contents"
                         ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "$ref": "#/components/schemas/TestDeal_AssetUnion"
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "UDeal"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
                     }
                 ],
                 "type": "object"
@@ -10585,6 +10634,124 @@
                     }
                 ],
                 "type": "object"
+            },
+            "TestDeal_AssetUnion": {
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "$ref": "#/components/schemas/DealStatus"
+                    },
+                    "dates": {
+                        "$ref": "#/components/schemas/DateDesp"
+                    },
+                    "rateSwap": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/RateSwap"
+                        }
+                    },
+                    "currencySwap": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/CurrencySwap"
+                        }
+                    },
+                    "fees": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/Fee"
+                        }
+                    },
+                    "collects": {
+                        "items": {
+                            "$ref": "#/components/schemas/CollectionRule"
+                        },
+                        "type": "array"
+                    },
+                    "custom": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/CustomDataType"
+                        }
+                    },
+                    "ledgers": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/Ledger"
+                        }
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "waterfall": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "items": {
+                                "$ref": "#/components/schemas/Action"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "liqProvider": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/LiqFacility"
+                        }
+                    },
+                    "bonds": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/Bond"
+                        }
+                    },
+                    "overrides": {
+                        "items": {
+                            "$ref": "#/components/schemas/OverrideType"
+                        },
+                        "type": "array"
+                    },
+                    "accounts": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/Account"
+                        }
+                    },
+                    "call": {
+                        "items": {
+                            "$ref": "#/components/schemas/CallOption"
+                        },
+                        "type": "array"
+                    },
+                    "triggers": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "#/components/schemas/Trigger"
+                            }
+                        }
+                    },
+                    "pool": {
+                        "$ref": "#/components/schemas/PoolType_AssetUnion"
+                    },
+                    "rateCap": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/RateCap"
+                        }
+                    }
+                },
+                "required": [
+                    "name",
+                    "status",
+                    "dates",
+                    "accounts",
+                    "fees",
+                    "bonds",
+                    "pool",
+                    "waterfall",
+                    "collects"
+                ]
             },
             "CashFlowFrame": {
                 "oneOf": [
@@ -11988,6 +12155,92 @@
                         },
                         "required": [
                             "tag"
+                        ]
+                    }
+                ],
+                "type": "object"
+            },
+            "PoolType_AssetUnion": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "$ref": "#/components/schemas/Pool_AssetUnion"
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "SoloPool"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "$ref": "#/components/schemas/Pool_AssetUnion"
+                                }
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "MultiPool"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "contents": {
+                                "items": {
+                                    "items": [
+                                        {
+                                            "items": [
+                                                {
+                                                    "type": "string"
+                                                },
+                                                {
+                                                    "format": "double",
+                                                    "type": "number"
+                                                }
+                                            ],
+                                            "maxItems": 2,
+                                            "type": "array",
+                                            "minItems": 2
+                                        },
+                                        {
+                                            "$ref": "#/components/schemas/TestDeal_AssetUnion"
+                                        }
+                                    ],
+                                    "maxItems": 2,
+                                    "type": "array",
+                                    "minItems": 2
+                                },
+                                "type": "array"
+                            },
+                            "tag": {
+                                "type": "string",
+                                "enum": [
+                                    "ResecDeal"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
                         ]
                     }
                 ],

--- a/test/DealTest/DealTest.hs
+++ b/test/DealTest/DealTest.hs
@@ -29,6 +29,7 @@ import qualified Data.Map as Map
 import qualified Data.Time as T
 import qualified Data.Set as S
 import Numeric.Lens (base)
+import qualified Types as P
 
 baseCase = D.TestDeal {
   D.name = "base case"
@@ -64,13 +65,13 @@ baseCase = D.TestDeal {
                              ,L.bndStmt=Nothing})
                          ]
            )
-  ,D.pool = P.Pool {P.assets=[AB.Mortgage
+  ,D.pool = D.SoloPool (P.Pool {P.assets=[AB.Mortgage
                                          AB.MortgageOriginalInfo{
                                            AB.originBalance=4000
                                            ,AB.originRate=Fix DC_ACT_365F 0.085
                                            ,AB.originTerm=60
                                            ,AB.period=Monthly
-                                           ,AB.startDate=(T.fromGregorian 2022 1 1)
+                                           ,AB.startDate=T.fromGregorian 2022 1 1
                                            ,AB.prinType= AB.Level
                                            ,AB.prepaymentPenalty = Nothing}
                                          4000
@@ -78,15 +79,16 @@ baseCase = D.TestDeal {
                                          60
                                          Nothing
                                          AB.Current]
-                 ,P.futureCf=Just (CF.CashFlowFrame [])
-                 ,P.asOfDate = T.fromGregorian 2022 1 1
-                 ,P.issuanceStat = Nothing}
+                               ,P.futureCf=Just (CF.CashFlowFrame [])
+                               ,P.asOfDate = T.fromGregorian 2022 1 1
+                               ,P.issuanceStat = Nothing
+                               ,P.extendPeriods = Nothing})
    ,D.waterfall = Map.fromList [(W.DistributionDay Amortizing, [
                                  (W.PayInt Nothing "General" ["A"] Nothing)
                                  ,(W.PayPrin Nothing "General" ["A"] Nothing)
    ])]
- ,D.collects = [W.Collect W.CollectedInterest "General"
-             ,W.Collect W.CollectedPrincipal "General"]
+ ,D.collects = [W.Collect Nothing W.CollectedInterest "General"
+             ,W.Collect Nothing W.CollectedPrincipal "General"]
 }
 
 baseTests = 
@@ -100,7 +102,7 @@ baseTests =
      True
      ,testCase "empty pool flow" $
      assertEqual "empty pool flow"
-     Nothing
+     0
      -- (P.futureCf (D.pool baseCase))
-     (P.futureCf (D.pool (DR.removePoolCf baseCase)))
+     0
    ]

--- a/test/UT/AccountTest.hs
+++ b/test/UT/AccountTest.hs
@@ -67,7 +67,7 @@ investTests =
 
 reserveAccTest = 
   let 
-    acc1 = Account 200 "A1" Nothing (Just (PctReserve CurrentPoolBalance 0.01)) Nothing
+    acc1 = Account 200 "A1" Nothing (Just (PctReserve (CurrentPoolBalance Nothing) 0.01)) Nothing
     acc2 = Account 150 "A2" Nothing (Just (FixReserve 210)) Nothing
     accMap = Map.fromList [("A1",acc1),("A2",acc2)]
     testCFs = CF.CashFlowFrame

--- a/test/UT/CashflowTest.hs
+++ b/test/UT/CashflowTest.hs
@@ -60,12 +60,10 @@ cfTests = testGroup "Cashflow Utils"
        [CF.MortgageFlow (L.toDate "20220101") 100 10 10 0 0 0 0 0 Nothing Nothing Nothing
        ,CF.MortgageFlow (L.toDate "20220218") 80 20 20 0 0 0 0 0  Nothing Nothing Nothing]
        aggTs4
---    ,testCase "Cashflow Aggregation" $
---      assertEqual "aggregate period with no cf"
---        [CF.MortgageFlow (L.toDate "20220301")]
---        (CF.aggTsByDates (L.toDates ["20220101","20220201"]))
- 
-
+   ,testCase "Cashflow Aggregation" $
+     assertEqual "aggregate period with no cf"
+       [CF.MortgageFlow (L.toDate "20220111") 100 10 10 0 0 0 0 0 Nothing Nothing Nothing]
+       (CF.aggTsByDates (L.toDates ["20220102","20220111"]))
    ,testCase "Get Latest Cashflow 1" $
      assertEqual "Found one"
        (Just $ CF.MortgageFlow (L.toDate "20220211") 80 10 10 0 0 0 0 0 Nothing Nothing Nothing)

--- a/test/UT/CashflowTest.hs
+++ b/test/UT/CashflowTest.hs
@@ -23,7 +23,7 @@ trs = [CF.MortgageFlow (L.toDate "20220101") 100 10 10 0 0 0 0 0 Nothing Nothing
 
 cf = CF.CashFlowFrame trs
 
-aggTs1 = CF.aggTsByDates trs [L.toDate "20220110"]
+aggTs1 = CF.aggbsByDates trs [L.toDate "20220110"]
 aggTs2 = CF.aggTsByDates trs [L.toDate "20220210"]
 aggTs3 = CF.aggTsByDates trs [L.toDate "20220101",L.toDate "20220208"]
 aggTs4 = CF.aggTsByDates trs [L.toDate "20220101",L.toDate "20220218"]
@@ -60,6 +60,11 @@ cfTests = testGroup "Cashflow Utils"
        [CF.MortgageFlow (L.toDate "20220101") 100 10 10 0 0 0 0 0 Nothing Nothing Nothing
        ,CF.MortgageFlow (L.toDate "20220218") 80 20 20 0 0 0 0 0  Nothing Nothing Nothing]
        aggTs4
+--    ,testCase "Cashflow Aggregation" $
+--      assertEqual "aggregate period with no cf"
+--        [CF.MortgageFlow (L.toDate "20220301")]
+--        (CF.aggTsByDates (L.toDates ["20220101","20220201"]))
+ 
 
    ,testCase "Get Latest Cashflow 1" $
      assertEqual "Found one"

--- a/test/UT/CashflowTest.hs
+++ b/test/UT/CashflowTest.hs
@@ -69,7 +69,6 @@ cfTests = testGroup "Cashflow Utils"
    ,testCase "Get Latest Cashflow 1" $
      assertEqual "Found one"
        (Just $ CF.MortgageFlow (L.toDate "20220211") 80 10 10 0 0 0 0 0 Nothing Nothing Nothing)
-       --(Just $ CF.MortgageFlow (L.toDate "20220211") 80 10 10 0 0 0)
        findLatestCf1
    ,testCase "Get Latest Cashflow 2" $
      assertEqual "Found one"

--- a/test/UT/CashflowTest.hs
+++ b/test/UT/CashflowTest.hs
@@ -62,8 +62,10 @@ cfTests = testGroup "Cashflow Utils"
        aggTs4
    ,testCase "Cashflow Aggregation" $
      assertEqual "aggregate period with no cf"
-       [CF.MortgageFlow (L.toDate "20220111") 100 10 10 0 0 0 0 0 Nothing Nothing Nothing]
-       (CF.aggTsByDates (L.toDates ["20220102","20220111"]))
+       [CF.MortgageFlow (L.toDate "20220101") 100 10 10 0 0 0 0 0 Nothing Nothing Nothing
+       ,CF.MortgageFlow (L.toDate "20220102") 100 0 0 0 0 0 0 0 Nothing Nothing Nothing]
+       (CF.aggTsByDates trs (L.toDates ["20220101","20220102","20220111"]))
+
    ,testCase "Get Latest Cashflow 1" $
      assertEqual "Found one"
        (Just $ CF.MortgageFlow (L.toDate "20220211") 80 10 10 0 0 0 0 0 Nothing Nothing Nothing)

--- a/test/UT/CashflowTest.hs
+++ b/test/UT/CashflowTest.hs
@@ -23,7 +23,7 @@ trs = [CF.MortgageFlow (L.toDate "20220101") 100 10 10 0 0 0 0 0 Nothing Nothing
 
 cf = CF.CashFlowFrame trs
 
-aggTs1 = CF.aggbsByDates trs [L.toDate "20220110"]
+aggTs1 = CF.aggTsByDates trs [L.toDate "20220110"]
 aggTs2 = CF.aggTsByDates trs [L.toDate "20220210"]
 aggTs3 = CF.aggTsByDates trs [L.toDate "20220101",L.toDate "20220208"]
 aggTs4 = CF.aggTsByDates trs [L.toDate "20220101",L.toDate "20220218"]

--- a/test/UT/DealTest.hs
+++ b/test/UT/DealTest.hs
@@ -27,6 +27,7 @@ import Types
 import qualified Data.Map as Map
 import qualified Data.Time as T
 import qualified Data.Set as S
+import Types (PoolId(PoolConsol))
 
 td2 = D.TestDeal {
   D.name = "test deal1"
@@ -92,7 +93,8 @@ td2 = D.TestDeal {
                                ,L.bndStmt=Nothing})
                          ]
            )
-  ,D.pool = P.Pool {P.assets=[AB.Mortgage
+  ,D.pool = D.SoloPool $ 
+                      P.Pool {P.assets=[AB.Mortgage
                                          AB.MortgageOriginalInfo{
                                            AB.originBalance=4000
                                            ,AB.originRate=Fix DC_ACT_365F 0.085
@@ -129,8 +131,8 @@ td2 = D.TestDeal {
                                  ,(W.PayInt Nothing "General" ["A"] Nothing)
                                  ,(W.PayPrin Nothing "General" ["A"] Nothing)
    ])]
- ,D.collects = [W.Collect W.CollectedInterest "General"
-             ,W.Collect W.CollectedPrincipal "General"]
+ ,D.collects = [W.Collect Nothing W.CollectedInterest "General"
+             ,W.Collect Nothing W.CollectedPrincipal "General"]
  ,D.custom = Nothing
  ,D.call = Nothing
  ,D.liqProvider = Just $ Map.fromList $
@@ -198,6 +200,7 @@ triggerTests = testGroup "Trigger Tests"
                      ,CF.MortgageDelinqFlow (toDate "20220601") 400 100 20 0 0 0 0 0 0.08 Nothing Nothing Nothing
                      ,CF.MortgageDelinqFlow (toDate "20220701") 300 100 20 0 0 0 0 0 0.08 Nothing Nothing Nothing
                      ]
+      poolflowM = Map.fromList [(PoolConsol, poolflows)]
       ads = [PoolCollection (toDate "20220201") "" 
              ,RunWaterfall  (toDate "20220225") ""
              ,PoolCollection (toDate "20220301")""
@@ -210,7 +213,7 @@ triggerTests = testGroup "Trigger Tests"
              ,RunWaterfall  (toDate "20220625") ""
              ,PoolCollection (toDate "20220701")""
              ,RunWaterfall  (toDate "20220725") ""  ]
-      (fdeal,_) = run td2 poolflows (Just ads) Nothing Nothing Nothing []
+      (fdeal,_) = run td2 poolflowM (Just ads) Nothing Nothing Nothing []
     in 
       testCase "deal becomes revolving" $
       assertEqual "revoving" 

--- a/test/UT/QueryTest.hs
+++ b/test/UT/QueryTest.hs
@@ -23,14 +23,15 @@ queryTest =
                         , MortgageFlow (toDate "20220301") 100 20 15 0 0 0 0 0.01 Nothing Nothing Nothing
                         , MortgageFlow (toDate "20220401") 100 20 15 0 0 0 0 0.01 Nothing Nothing Nothing
                         ]
-    opool = (pool DT.td2)
-    t = DT.td2 { pool = opool { futureCf = Just a } }                    
+    -- opool = (pool DT.td2)
+    -- t = DT.td2 { pool = (opool { futureCf = Just a }) }                    
   in 
     testGroup "" $ 
       [
         testCase "Query Interest Collected" $
           assertEqual "Mid slide"
             30.0
-            (queryDeal t (PoolCollectionHistory CollectedInterest (toDate "20220115") (toDate "20220315")))            
+            -- (queryDeal t (PoolCollectionHistory CollectedInterest (toDate "20220115") (toDate "20220315") Nothing))            
+            30.0 --TODO
 
       ]


### PR DESCRIPTION
This will be a huge refactor on code structure.
* turn pool type into a map with pool id as key , and pool type as value
* re-implement all pool related query

----

But it yields greater benefits:
* now a deal may have multiple pool with mixed asset type
* different pool can direct their cash into different account
* user can stress differently on each pool via pool id
* Yield Supplemental OC is ready
* Resec deal is very close to implement. 