### PR TITLE
Bugfix run pool cf order

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for Hastructure
 
+## 0.28.16
+### 2024-8-6
+* FIX: correct `runPool` cashflow order and add UT 
+
 ## 0.28.15
 ### 2024-7-31
 * FIX: enable compound formula on `weighted average` formula.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -298,7 +298,8 @@ data PoolTypeWrap = LPool (DB.PoolType AB.Loan)
 type RunPoolTypeRtn = Map.Map PoolId (CF.CashFlowFrame, Map.Map CutoffFields Balance)
 
 patchCumulativeToPoolRun :: RunPoolTypeRtn -> RunPoolTypeRtn
-patchCumulativeToPoolRun = Map.map (\(CF.CashFlowFrame _ txns,stats) -> (CF.CashFlowFrame (0,Lib.toDate "19000101",Nothing) (CF.patchCumulative (0,0,0,0,0,0) txns []),stats))
+patchCumulativeToPoolRun = Map.map 
+                            (\(CF.CashFlowFrame _ txns,stats) -> (CF.CashFlowFrame (0,Lib.toDate "19000101",Nothing) (CF.patchCumulative (0,0,0,0,0,0) [] txns),stats))
 
 wrapRunPoolType :: PoolTypeWrap -> Maybe AP.ApplyAssumptionType -> Maybe [RateAssumption] ->  RunPoolTypeRtn
 wrapRunPoolType (MPool pt) assump mRates = D.runPoolType pt assump $ Just (AP.NonPerfAssumption{AP.interest = mRates})

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -103,7 +103,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.28.15"
+version1 = Version "0.28.16"
 
 
 data DealType = MDeal (DB.TestDeal AB.Mortgage)

--- a/test/UT/CashflowTest.hs
+++ b/test/UT/CashflowTest.hs
@@ -315,6 +315,11 @@ testCumStat =
     cflow1 = [CF.MortgageDelinqFlow (L.toDate "20230201") 200 30 20 30 1 2 3 4 0.0 Nothing (Just 15) (Just (30,30,1,2,3,4))
              ,CF.MortgageDelinqFlow (L.toDate "20230301") 190 40 30 40 1 2 3 4 0.0 Nothing (Just 20) (Just (70,70,2,4,6,8))
              ,CF.MortgageDelinqFlow (L.toDate "20230401") 180 50 40 50 1 2 3 4 0.0 Nothing (Just 30) (Just (120,120,3,6,9,12))]
+    
+    cflow2 =[CF.MortgageDelinqFlow (L.toDate "20230101") 100 20 10 20 1 2 3 4 0.0 Nothing (Just 10) Nothing
+        ,CF.MortgageDelinqFlow (L.toDate "20230201") 200 30 20 30 1 2 3 4 0.0 Nothing (Just 15) Nothing
+        ,CF.MortgageDelinqFlow (L.toDate "20230301") 190 40 30 40 1 2 3 4 0.0 Nothing (Just 20) Nothing
+        ,CF.MortgageDelinqFlow (L.toDate "20230401") 180 50 40 50 1 2 3 4 0.0 Nothing (Just 30) Nothing]
   in 
     testGroup "Test on calc CumStat"
     [ testCase "MortDelinq CumStat" $
@@ -357,6 +362,14 @@ testCumStat =
         assertEqual "sum prepayment penalty"
         65
         (CF.sumPoolFlow (CF.CashFlowFrame dummySt cflow1) CollectedPrepaymentPenalty)
+      ,testCase "Patch Cumulative 0" $
+        assertEqual "patch cum stats"
+        [CF.MortgageDelinqFlow (L.toDate "20230101") 100 20 10 20 1 2 3 4 0.0 Nothing (Just 10) (Just (20,20,1,2,3,4))
+        ,CF.MortgageDelinqFlow (L.toDate "20230201") 200 30 20 30 1 2 3 4 0.0 Nothing (Just 15) (Just (50,50,2,4,6,8))
+        ,CF.MortgageDelinqFlow (L.toDate "20230301") 190 40 30 40 1 2 3 4 0.0 Nothing (Just 20) (Just (90,90,3,6,9,12))
+        ,CF.MortgageDelinqFlow (L.toDate "20230401") 180 50 40 50 1 2 3 4 0.0 Nothing (Just 30) (Just (140,140,4,8,12,16))
+        ]
+        (CF.patchCumulative (0,0,0,0,0,0) [] cflow2)
     ]
 
 testClawIntTest = 


### PR DESCRIPTION
wrong argument order was passed into `patchCumulativeToPoolRun`