### PR TITLE
0.30.x

### DIFF
--- a/.github/workflows/docker-image-dev-by-tag.yml
+++ b/.github/workflows/docker-image-dev-by-tag.yml
@@ -40,6 +40,6 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/hastructure:dev, ${{ steps.meta.outputs.tags }}
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/hastructure:dev, ${{ secrets.DOCKER_HUB_USERNAME }}/hastructure:${{ steps.meta.outputs.tags }}
           cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/hastructure:buildcache
           cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/hastructure:buildcache,mode=max  

--- a/.github/workflows/docker-image-dev-by-tag.yml
+++ b/.github/workflows/docker-image-dev-by-tag.yml
@@ -46,6 +46,6 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/hastructure:dev, ${{ secrets.DOCKER_HUB_USERNAME }}/hastructure:${{ steps.meta.outputs.tags }}
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/hastructure:dev, ${{ steps.meta.outputs.tags }}
           cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/hastructure:buildcache
           cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/hastructure:buildcache,mode=max  

--- a/.github/workflows/docker-image-dev-by-tag.yml
+++ b/.github/workflows/docker-image-dev-by-tag.yml
@@ -33,13 +33,13 @@ jobs:
           ls -la .
           rm -rf /opt/ghc
           rm -rf /opt/hostedtoolcache
-
+          
       -
         name: Build and push
         uses: docker/build-push-action@v3
         with:
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/hastructure:dev
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/hastructure:dev, ${{ steps.meta.outputs.tags }}
           cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/hastructure:buildcache
-          cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/hastructure:buildcache,mode=max     
+          cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/hastructure:buildcache,mode=max  

--- a/Hastructure.cabal
+++ b/Hastructure.cabal
@@ -160,6 +160,7 @@ test-suite Hastructure-test
       UT.BondTest
       UT.CashflowTest
       UT.DealTest
+      UT.DealTest2
       UT.ExpTest
       UT.InterestRateTest
       UT.LibTest

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -103,7 +103,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.29.16"
+version1 = Version "0.29.17"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -103,7 +103,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.29.15"
+version1 = Version "0.29.16"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -103,7 +103,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.29.13"
+version1 = Version "0.29.14"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -103,7 +103,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.29.12"
+version1 = Version "0.29.13"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -103,7 +103,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.29.8"
+version1 = Version "0.29.9"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -103,7 +103,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.29.14"
+version1 = Version "0.29.15"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -103,7 +103,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.29.9"
+version1 = Version "0.29.10"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -103,7 +103,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.29.11"
+version1 = Version "0.29.12"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -102,7 +102,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.29.5"
+version1 = Version "0.29.6"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -102,7 +102,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.29.7"
+version1 = Version "0.29.8"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -44,6 +44,7 @@ import qualified Data.ByteString.Char8 as BS
 import Lucid hiding (type_)
 import Network.Wai
 import Network.Wai.Handler.Warp
+import Network.Wai.Middleware.Cors
 import qualified Data.Aeson.Parser
 import Language.Haskell.TH
 
@@ -472,7 +473,9 @@ data Config = Config { port :: Int}
 instance FromJSON Config
 
 app :: Application
-app = serve (Proxy :: Proxy API) myServer
+-- app = serve (Proxy :: Proxy API) myServer
+app = simpleCors $ serve (Proxy :: Proxy API) myServer
+
 
 
 main :: IO ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -103,7 +103,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.29.10"
+version1 = Version "0.29.11"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -102,7 +102,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.29.6"
+version1 = Version "0.29.7"
 
 
 

--- a/src/Asset.hs
+++ b/src/Asset.hs
@@ -167,6 +167,10 @@ buildPrepayRates ds mPa =
                                     Util.toPeriodRateByInterval
                                     (paddingDefault 0.0 vs (pred size))
                                     (getIntervalDays ds)
+    Just (A.PrepaymentVecPadding vs) -> zipWith 
+                                         Util.toPeriodRateByInterval
+                                         (paddingDefault (last vs) vs (pred size))
+                                         (getIntervalDays ds)
     _ -> error ("failed to find prepayment type"++ show mPa)
   where
     size = length ds
@@ -181,6 +185,10 @@ buildDefaultRates ds mDa =
                                 Util.toPeriodRateByInterval
                                 (paddingDefault 0.0 vs (pred size))
                                 (getIntervalDays ds)
+    Just (A.DefaultVecPadding vs) -> zipWith 
+                                      Util.toPeriodRateByInterval
+                                      (paddingDefault (last vs) vs (pred size))
+                                      (getIntervalDays ds)
     Just (A.DefaultAtEndByRate r rAtEnd)
       -> case size of 
           0 -> []

--- a/src/AssetClass/FixedAsset.hs
+++ b/src/AssetClass/FixedAsset.hs
@@ -102,6 +102,8 @@ instance Ast.Asset FixedAsset where
         cumuDepreciation = tail $ scanl (+) cumuDep amortizedBals 
         
         txns = zipWith6 CF.FixedFlow pdates scheduleBals amortizedBals cumuDepreciation units cash
+        futureTxns = cutBy Inc Future asOfDay txns
+        begBal = CF.buildBegBal futureTxns
       in 
-        (CF.CashFlowFrame (head scheduleBals,asOfDay,Nothing) $ cutBy Inc Future asOfDay txns, Map.empty)
+        (CF.CashFlowFrame (begBal,asOfDay,Nothing) $ futureTxns, Map.empty)
   

--- a/src/AssetClass/Lease.hs
+++ b/src/AssetClass/Lease.hs
@@ -211,7 +211,7 @@ instance Asset Lease where
       = fst . patchBalance $ RegularLease (LeaseInfo sd ot dp dr ob) bal ot st
 
     projCashflow l asOfDay ((AP.LeaseAssump gapAssump rentAssump ed exStress),_,_) mRates
-      = (CF.CashFlowFrame (0,asOfDay,Nothing) allTxns, Map.empty)  
+      = (CF.CashFlowFrame (begBal,asOfDay,Nothing) allTxns, Map.empty)  
       where 
         currentCf = calcCashflow l asOfDay mRates
         -- (rc,rcCurve,mgTbl,gapDays,ed) = extractAssump (A.LeaseAssump gapAssump rentAssump) -- (0.0,mkTs [],([(0.0,0)],0),0,epocDate)-- `debug` ("7")
@@ -232,6 +232,8 @@ instance Asset Lease where
                       []
         newCfs = [ calcCashflow l asOfDay mRates | l <- newLeases ]  -- `debug` ("new leases"++ show newLeases )
         allTxns = view CF.cashflowTxn currentCf ++ (concat $ (view CF.cashflowTxn) <$> newCfs)
+        begBal = CF.buildBegBal allTxns
+        
 
     getCurrentBal l = case l of 
                         StepUpLease _ _ bal _ _ -> bal

--- a/src/AssetClass/Loan.hs
+++ b/src/AssetClass/Loan.hs
@@ -143,7 +143,7 @@ instance Asset Loan where
                       in 
                         divideBB cb (scheduleBals!!(ot - rt))
                      _ -> 1.0  
-      (txns,_) = projectLoanFlow ((ob,ot,getOriginRate pl), cb,lastPayDate,prinPayType,dc,cr,initFactor) (cfDates,defRates,ppyRates,rateVector,remainTerms)  `debug` (" rateVector"++show rateVector)
+      (txns,_) = projectLoanFlow ((ob,ot,getOriginRate pl), cb,lastPayDate,prinPayType,dc,cr,initFactor) (cfDates,defRates,ppyRates,rateVector,remainTerms)  -- `debug` (" rateVector"++show rateVector)
       (futureTxns,historyM) = CF.cutoffTrs asOfDay (patchLossRecovery txns recoveryAssump)
 
   -- ^ Project cashflow for defautled loans 

--- a/src/AssetClass/Loan.hs
+++ b/src/AssetClass/Loan.hs
@@ -127,7 +127,7 @@ instance Asset Loan where
                asOfDay 
                (A.LoanAssump defaultAssump prepayAssump recoveryAssump ams,_,_)
                mRate 
-    = (applyHaircut ams (CF.CashFlowFrame (cb,asOfDay,Nothing) futureTxns), historyM)
+    = (applyHaircut ams (CF.CashFlowFrame (begBal,asOfDay,Nothing) futureTxns), historyM)
     where
       recoveryLag = maybe 0 getRecoveryLag recoveryAssump
       lastPayDate:cfDates = lastN (rt + recoveryLag + 1) $ sd:getPaymentDates pl recoveryLag
@@ -145,6 +145,7 @@ instance Asset Loan where
                      _ -> 1.0  
       (txns,_) = projectLoanFlow ((ob,ot,getOriginRate pl), cb,lastPayDate,prinPayType,dc,cr,initFactor) (cfDates,defRates,ppyRates,rateVector,remainTerms)  -- `debug` (" rateVector"++show rateVector)
       (futureTxns,historyM) = CF.cutoffTrs asOfDay (patchLossRecovery txns recoveryAssump)
+      begBal = CF.buildBegBal futureTxns
 
   -- ^ Project cashflow for defautled loans 
   projCashflow m@(PersonalLoan (LoanOriginalInfo ob or ot p sd prinPayType _) cb cr rt (Defaulted (Just defaultedDate))) 
@@ -158,8 +159,9 @@ instance Asset Loan where
         _txns = [  CF.LoanFlow d 0 0 0 0 0 r 0 cr Nothing | (d,r) <- zip cf_dates2 recoveries ]
         (_, txns) = splitByDate (beforeRecoveryTxn++_txns) asOfDay EqToRight -- `debug` ("AS OF Date"++show asOfDay)
         (futureTxns,historyM) = CF.cutoffTrs asOfDay txns 
+        begBal = CF.buildBegBal futureTxns
       in 
-        (CF.CashFlowFrame (cb,asOfDay,Nothing) futureTxns, historyM)
+        (CF.CashFlowFrame (begBal,asOfDay,Nothing) futureTxns, historyM)
 
   projCashflow m@(PersonalLoan (LoanOriginalInfo ob or ot p sd prinPayType _) cb cr rt (Defaulted Nothing)) asOfDay assumps _
     = (CF.CashFlowFrame (cb,asOfDay,Nothing) [CF.LoanFlow asOfDay 0 0 0 0 0 0 0 cr Nothing],Map.empty)

--- a/src/AssetClass/MixedAsset.hs
+++ b/src/AssetClass/MixedAsset.hs
@@ -223,7 +223,7 @@ projAssetUnionList assets d (A.PoolLevel assetPerf) mRate =
     cfs = fst <$> results
     bals = snd <$> results
   in 
-    (foldl1 CF.mergePoolCf cfs, Map.unionsWith (+) bals)
+    (foldl1 CF.mergeCf cfs, Map.unionsWith (+) bals)
 
 projAssetUnionList assets d _ mRate = error " not implemented on asset level assumption for revolving pool"
 

--- a/src/AssetClass/MixedAsset.hs
+++ b/src/AssetClass/MixedAsset.hs
@@ -223,7 +223,8 @@ projAssetUnionList assets d (A.PoolLevel assetPerf) mRate =
     cfs = fst <$> results
     bals = snd <$> results
   in 
-    (foldl1 CF.mergeCf cfs, Map.unionsWith (+) bals)
+    (foldl1 CF.mergePoolCf cfs, Map.unionsWith (+) bals)
+    -- (foldl1 CF.mergeCf cfs, Map.unionsWith (+) bals)
 
 projAssetUnionList assets d _ mRate = error " not implemented on asset level assumption for revolving pool"
 

--- a/src/AssetClass/MixedAsset.hs
+++ b/src/AssetClass/MixedAsset.hs
@@ -217,6 +217,7 @@ projAssetUnion (ACM.PF ast) d assumps mRates = P.projCashflow ast d assumps mRat
 projAssetUnion x _ _ _ = error ("Failed to match  proj AssetUnion"++ show x)
 
 projAssetUnionList :: [ACM.AssetUnion] -> Date -> A.ApplyAssumptionType -> Maybe [RateAssumption] -> (CF.CashFlowFrame, Map.Map CutoffFields Balance)
+projAssetUnionList [] d (A.PoolLevel assetPerf) mRate = (CF.CashFlowFrame (0,d,Nothing) [], Map.empty)
 projAssetUnionList assets d (A.PoolLevel assetPerf) mRate =
   let 
     results = [ projAssetUnion asset d assetPerf mRate | asset <- assets ]
@@ -224,7 +225,6 @@ projAssetUnionList assets d (A.PoolLevel assetPerf) mRate =
     bals = snd <$> results
   in 
     (foldl1 CF.mergePoolCf cfs, Map.unionsWith (+) bals)
-    -- (foldl1 CF.mergeCf cfs, Map.unionsWith (+) bals)
 
 projAssetUnionList assets d _ mRate = error " not implemented on asset level assumption for revolving pool"
 

--- a/src/Assumptions.hs
+++ b/src/Assumptions.hs
@@ -14,7 +14,7 @@ module Assumptions (BondPricingInput(..)
                     ,NonPerfAssumption(..),AssetPerf
                     ,AssetDelinquencyAssumption(..)
                     ,AssetDelinqPerfAssumption(..),AssetDefaultedPerfAssumption(..)
-                    ,getCDR,calcResetDates,AssumpReceipes,IssueBondEvent(..)
+                    ,getCDR,calcResetDates,IssueBondEvent(..)
                     ,TagMatchRule(..),ObligorStrategy(..),RefiEvent(..)
                     ,FieldMatchRule(..))
 where
@@ -135,18 +135,6 @@ data RecoveryAssumption = Recovery (Rate,Int)                    -- ^ recovery r
                         | RecoveryTiming (Rate,[Rate])           -- ^ recovery rate, with distribution of recoveries
                         | RecoveryByDays Rate [(Int, Rate)]      -- ^ recovery rate, with distribution of recoveries by offset dates
                         deriving (Show,Generic,Read)
-
-data AssumpReceipe = DefaultAssump AssetDefaultAssumption
-                   | PrepayAssump AssetPrepayAssumption
-                   | DelinqAssump AssetDelinquencyAssumption
-                   | RecoveryAssump RecoveryAssumption
-                   | RunInt 
-                   | RunSchedulePrincipal
-                   | RunPmt
-                   | RunHaircut [(PoolSource, Rate)]
-                   deriving (Show,Generic)
-                   
-type AssumpReceipes = [AssumpReceipe]
 
 data LeaseAssetGapAssump = GapDays Int                         -- ^ days between leases, when creating dummy leases
                          | GapDaysByAmount [(Amount,Int)] Int  -- ^ days depends on the size of leases, when a default a default days for size greater

--- a/src/Assumptions.hs
+++ b/src/Assumptions.hs
@@ -115,6 +115,7 @@ data AssumptionInput = Single ApplyAssumptionType  NonPerfAssumption            
 data AssetDefaultAssumption = DefaultConstant Rate              -- ^ using constant default rate
                             | DefaultCDR Rate                   -- ^ using annualized default rate
                             | DefaultVec [Rate]                 -- ^ using default rate vector
+                            | DefaultVecPadding [Rate]                 -- ^ using default rate vector
                             | DefaultByAmt (Balance,[Rate])
                             | DefaultAtEnd                      -- ^ default 100% at end
                             | DefaultAtEndByRate Rate Rate      -- ^ life time default rate and default rate at end
@@ -123,6 +124,7 @@ data AssetDefaultAssumption = DefaultConstant Rate              -- ^ using const
 data AssetPrepayAssumption = PrepaymentConstant Rate
                            | PrepaymentCPR Rate 
                            | PrepaymentVec [Rate] 
+                           | PrepaymentVecPadding [Rate] 
                            | PrepayByAmt (Balance,[Rate])
                            deriving (Show,Generic,Read)
 

--- a/src/Assumptions.hs
+++ b/src/Assumptions.hs
@@ -115,10 +115,11 @@ data AssumptionInput = Single ApplyAssumptionType  NonPerfAssumption            
 data AssetDefaultAssumption = DefaultConstant Rate              -- ^ using constant default rate
                             | DefaultCDR Rate                   -- ^ using annualized default rate
                             | DefaultVec [Rate]                 -- ^ using default rate vector
-                            | DefaultVecPadding [Rate]                 -- ^ using default rate vector
+                            | DefaultVecPadding [Rate]          -- ^ using default rate vector
                             | DefaultByAmt (Balance,[Rate])
                             | DefaultAtEnd                      -- ^ default 100% at end
                             | DefaultAtEndByRate Rate Rate      -- ^ life time default rate and default rate at end
+                            | DefaultStressByTs Ts AssetDefaultAssumption
                             deriving (Show,Generic,Read)
 
 data AssetPrepayAssumption = PrepaymentConstant Rate
@@ -126,6 +127,7 @@ data AssetPrepayAssumption = PrepaymentConstant Rate
                            | PrepaymentVec [Rate] 
                            | PrepaymentVecPadding [Rate] 
                            | PrepayByAmt (Balance,[Rate])
+                           | PrepayStressByTs Ts AssetPrepayAssumption
                            deriving (Show,Generic,Read)
 
 data AssetDelinquencyAssumption = DelinqCDR Rate (Lag,Rate)                 -- ^ Annualized Rate to Delinq status , period lag become defaulted, loss rate, period lag become loss

--- a/src/Cashflow.hs
+++ b/src/Cashflow.hs
@@ -20,7 +20,7 @@ module Cashflow (CashFlowFrame(..),Principals,Interests,Amount
                 ,tsCumDefaultBal,tsCumDelinqBal,tsCumLossBal,tsCumRecoveriesBal
                 ,TsRow(..),cfAt,cutoffTrs,patchCumulative,extendTxns,dropTailEmptyTxns
                 ,cashflowTxn,clawbackInt,scaleTsRow,mflowFeePaid, currentCumulativeStat, patchCumulativeAtInit
-                ,mergeCf,buildStartTsRow
+                ,mergeCf,buildStartTsRow, sliceCfFrame
                 ,txnCumulativeStats,consolidateCashFlow, cfBeginStatus, getBegBalCashFlowFrame
                 ,splitCashFlowFrameByDate, mergePoolCf2, buildBegBal, extendCashFlow, patchBalance) where
 
@@ -842,6 +842,20 @@ mergePoolCf cf1@(CashFlowFrame st1 txns1) cf2@(CashFlowFrame st2 txns2)
   where 
     [startDate1,startDate2] = firstDate <$> [cf1,cf2]
     -- rightToLeft = startDate1 >= startDate2
+
+sliceCfFrame :: Date -> Date -> RangeType -> CashFlowFrame -> CashFlowFrame
+sliceCfFrame sd ed rt (CashFlowFrame st txns) 
+  = let 
+      txns' = case rt of 
+                EE -> filter (\x -> (mflowDate x > sd) && (mflowDate x < ed)) txns
+                EI -> filter (\x -> (mflowDate x > sd) && (mflowDate x <= ed)) txns
+                II -> filter (\x -> (mflowDate x >= sd) && (mflowDate x <= ed)) txns
+                IE -> filter (\x -> (mflowDate x >= sd) && (mflowDate x < ed)) txns
+    in 
+      CashFlowFrame st txns'
+
+
+
 
 aggTs :: [TsRow] -> [TsRow] -> [TsRow]
 aggTs [] [] = []

--- a/src/Cashflow.hs
+++ b/src/Cashflow.hs
@@ -528,7 +528,7 @@ firstDate (CashFlowFrame _ [r]) = getDate r
 firstDate (CashFlowFrame _ (r:rs)) = getDate r
 
 
--- ! combine two cashflow frame 
+-- ! combine two cashflow frames from two entities
 -- ! cashflow earlier on the left ,later cashflow on the right
 combine :: CashFlowFrame -> CashFlowFrame -> CashFlowFrame 
 combine (CashFlowFrame st1 []) (CashFlowFrame st2 []) = CashFlowFrame st1 []
@@ -536,7 +536,6 @@ combine (CashFlowFrame _ []) cf2 = cf2
 combine cf1 (CashFlowFrame _ []) = cf1
 combine cf1@(CashFlowFrame st1@(begBal1,begDate1,acc1) txn1) cf2@(CashFlowFrame st2@(begBal2,begDate2,acc2) txn2) 
   | begDate1 > begDate2 = combine cf2 cf1
---  | begDate1 == begDate2 = combine cf2 cf1
   | otherwise =
     let 
       txns = combineTss [] txn1 txn2

--- a/src/Cashflow.hs
+++ b/src/Cashflow.hs
@@ -22,7 +22,7 @@ module Cashflow (CashFlowFrame(..),Principals,Interests,Amount
                 ,cashflowTxn,clawbackInt,scaleTsRow,mflowFeePaid, currentCumulativeStat, patchCumulativeAtInit
                 ,mergeCf,buildStartTsRow
                 ,txnCumulativeStats,consolidateCashFlow, cfBeginStatus, getBegBalCashFlowFrame
-                ,splitCashFlowFrameByDate, mergePoolCf2) where
+                ,splitCashFlowFrameByDate, mergePoolCf2, buildBegBal) where
 
 import Data.Time (Day)
 import Data.Fixed
@@ -391,6 +391,11 @@ addTsCF (FixedFlow d1 b1 dep1 cd1 u1 c1) (FixedFlow d2 b2 dep2 cd2 u2 c2)
   = FixedFlow d1 (min b1 b2) (dep1 + dep2) (cd1 + cd2) u2 (c1 + c2)
 addTsCF (ReceivableFlow d1 b1 af1 p1 fp1 def1 rec1 los1 st1) (ReceivableFlow d2 b2 af2 p2 fp2 def2 rec2 los2 st2)
   = ReceivableFlow d1 (min b1 b2) (af1 + af2) (p1 + p2) (fp1 + fp2) (def1 + def2) (rec1 + rec2) (los1 + los2) (maxStats st1 st2)
+
+
+buildBegBal :: [TsRow] -> Balance
+buildBegBal [] = 0
+buildBegBal (x:_) = mflowBegBalance x
 
 
 sumTs :: [TsRow] -> Date -> TsRow

--- a/src/Cashflow.hs
+++ b/src/Cashflow.hs
@@ -195,27 +195,27 @@ instance Show CashFlowFrame where
     let 
         ds = [ show d | d <- getDates txns]
         rowHeader = [TT.Header h | h <- ds ]
-        getCs (CashFlow {}) = ["Date","Amount"]
-        getCs (BondFlow {}) = ["Date", "Balance", "Principal", "Interest"]
-        getCs (MortgageFlow {}) = ["Date", "Balance", "Principal", "Interest", "Prepayment", "Default", "Recovery", "Loss", "IRate", "BorrowerNum", "PrepaymentPenalty", "CumulativeStat"]
-        getCs (MortgageDelinqFlow {}) = ["Date", "Balance", "Principal", "Interest", "Prepayment", "Delinquent", "Default", "Recovery", "Loss", "IRate", "BorrowerNum", "PrepaymentPenalty", "CumulativeStat"]
-        getCs (LoanFlow {}) = ["Date", "Balance", "Principal", "Interest", "Prepayment", "Default", "Recovery", "Loss", "IRate", "CumulativeStat"]
-        getCs (LeaseFlow {}) = ["Date", "Balance", "Rental"]
-        getCs (FixedFlow {}) = ["Date", "Balance", "NewDepreciation", "Depreciation", "Balance", "Amount"]
-        getCs (ReceivableFlow {}) = ["Date", "Balance", "AccuredFee", "Principal", "FeePaid", "Default", "Recovery", "Loss", "CumulativeStat"]
+        getCs (CashFlow {}) = ["Amount"]
+        getCs (BondFlow {}) = ["Balance", "Principal", "Interest"]
+        getCs (MortgageFlow {}) = ["Balance", "Principal", "Interest", "Prepayment", "Default", "Recovery", "Loss", "IRate", "BorrowerNum", "PrepaymentPenalty", "CumulativeStat"]
+        getCs (MortgageDelinqFlow {}) = [ "Balance", "Principal", "Interest", "Prepayment", "Delinquent", "Default", "Recovery", "Loss", "IRate", "BorrowerNum", "PrepaymentPenalty", "CumulativeStat"]
+        getCs (LoanFlow {}) = ["Balance", "Principal", "Interest", "Prepayment", "Default", "Recovery", "Loss", "IRate", "CumulativeStat"]
+        getCs (LeaseFlow {}) = [ "Balance", "Rental"]
+        getCs (FixedFlow {}) = [ "Balance", "NewDepreciation", "Depreciation", "Balance", "Amount"]
+        getCs (ReceivableFlow {}) = [ "Balance", "AccuredFee", "Principal", "FeePaid", "Default", "Recovery", "Loss", "CumulativeStat"]
         colHeader = [TT.Header c | c <- getCs (head txns) ]
-        getRs (CashFlow d a) = [show d, show a]
-        getRs (BondFlow d b p i) = [show d, show b, show p, show i]
-        getRs (MortgageFlow d b p i prep def rec los rat mbn pp st) = [show d, show b, show p, show i, show prep, show def, show rec, show los, show rat, show mbn, show pp, show st]
-        getRs (MortgageDelinqFlow d b p i prep delinq def rec los rat mbn pp st) = [show d, show b, show p, show i, show prep, show delinq, show def, show rec, show los, show rat, show mbn, show pp, show st]
-        getRs (LoanFlow d b p i prep def rec los rat st) = [show d, show b, show p, show i, show prep, show def, show rec, show los, show rat, show st]
-        getRs (LeaseFlow d b r) = [show d, show b, show r]
-        getRs (FixedFlow d b ndep dep c a) = [show d, show b, show ndep, show dep, show c, show a]
-        getRs (ReceivableFlow d b af p fp def rec los st) = [show d, show b, show af, show p, show fp, show def, show rec, show los, show st]
+        getRs (CashFlow d a) = [show a]
+        getRs (BondFlow d b p i) = [ show b, show p, show i]
+        getRs (MortgageFlow d b p i prep def rec los rat mbn pp st) = [ show b, show p, show i, show prep, show def, show rec, show los, show rat, show mbn, show pp, show st]
+        getRs (MortgageDelinqFlow d b p i prep delinq def rec los rat mbn pp st) = [ show b, show p, show i, show prep, show delinq, show def, show rec, show los, show rat, show mbn, show pp, show st]
+        getRs (LoanFlow d b p i prep def rec los rat st) = [ show b, show p, show i, show prep, show def, show rec, show los, show rat, show st]
+        getRs (LeaseFlow d b r) = [ show b, show r]
+        getRs (FixedFlow d b ndep dep c a) = [ show b, show ndep, show dep, show c, show a]
+        getRs (ReceivableFlow d b af p fp def rec los st) = [ show b, show af, show p, show fp, show def, show rec, show los, show st]
         values = [ getRs txn  | txn <- txns ]
         tbl = TT.Table (TT.Group TT.SingleLine rowHeader) (TT.Group TT.SingleLine colHeader) values
     in 
-        A.render id id id tbl
+        show st <> "\n" <> A.render id id id tbl
 
 
 sizeCashFlowFrame :: CashFlowFrame -> Int

--- a/src/Deal.hs
+++ b/src/Deal.hs
@@ -410,7 +410,7 @@ run t@TestDeal{accounts=accMap,fees=feeMap,triggers=mTrgMap,bonds=bndMap,status=
                else
                  let 
                    (dAfterWaterfall, rc2, newLogsWaterfall) = foldl (performActionWrap d) (dRunWithTrigger0,rc1,log) waterfallToExe 
-                   (dRunWithTrigger1, rc3,ads2, newLogs2) = runTriggers (dAfterWaterfall,rc2,ads1) d EndDistributionWF  
+                   (dRunWithTrigger1, rc3, ads2, newLogs2) = runTriggers (dAfterWaterfall,rc2,ads1) d EndDistributionWF  
                    
                  in 
                    run dRunWithTrigger1 (runPoolFlow rc3) (Just ads2) rates calls rAssump (newLogsWaterfall++newLogs2++logsBeforeDist++[RunningWaterfall d waterfallKey]) 

--- a/src/Deal.hs
+++ b/src/Deal.hs
@@ -668,7 +668,7 @@ data ExpectReturn = DealStatus
                   deriving (Show,Generic)
 
 priceBonds :: TestDeal a -> AP.BondPricingInput -> Map.Map String L.PriceResult
-priceBonds t (AP.DiscountCurve d dc) = Map.map (L.priceBond d dc) (bonds t)
+priceBonds t (AP.DiscountCurve d dc) = Map.map (L.priceBond d dc) (viewBondsInMap t)
 priceBonds t@TestDeal {bonds = bndMap} (AP.RunZSpread curve bond_prices) 
   = Map.mapWithKey 
       (\bn (pd,price)-> L.ZSpread $

--- a/src/Deal/DealAction.hs
+++ b/src/Deal/DealAction.hs
@@ -545,9 +545,7 @@ performActionWrap d
                   (W.BuyAsset ml pricingMethod accName _)
   = error $ "Missing revolving Assumption(asset assumption & asset to buy)" ++ name t
 
--- TODO need to sell assets/ in the future , in run time
--- TODO need to remove assets/cashflow frame
--- TODO need to set a limit
+-- TODO need to set a limit to sell
 performActionWrap d 
                   (t@TestDeal{accounts = accMap, pool = pt}  
                   ,rc@RunContext{runPoolFlow = pcf}
@@ -590,7 +588,7 @@ performActionWrap d
      liqComment = LiquidationProceeds (fromMaybe [] mPid)
      accMapAfterLiq = Map.adjust (A.deposit liqAmt d liqComment) an accMap
      -- REMOVE future cf
-     newPfInRc = foldr (\k acc -> (Map.adjust (set CF.cashflowTxn []) k acc)) pcf  (Map.keys poolMapToLiq)
+     newPfInRc = foldr (Map.adjust (set CF.cashflowTxn [])) pcf  (Map.keys poolMapToLiq)
    in 
      (t {accounts = accMapAfterLiq , pool = newPt} , rc {runPoolFlow = newPfInRc}, logs )
 

--- a/src/Deal/DealAction.hs
+++ b/src/Deal/DealAction.hs
@@ -399,7 +399,9 @@ evalExtraSupportBalance d t (W.WithCondition pre s)
   | testPre d t pre = evalExtraSupportBalance d t s
   | otherwise = [0]
 evalExtraSupportBalance d t@TestDeal{accounts=accMap} (W.SupportAccount an _) = [A.accBalance $ accMap Map.! an]
-evalExtraSupportBalance d t@TestDeal{liqProvider=Just liqMap} (W.SupportLiqFacility liqName) = [ fromMaybe (fromRational (toRational infinity)) (CE.liqCredit (liqMap Map.! liqName))] -- `debug` ("Returning"++ show [ fromMaybe 1e100 (CE.liqCredit (liqMap Map.! liqName))])
+evalExtraSupportBalance d t@TestDeal{liqProvider=Just liqMap} (W.SupportLiqFacility liqName) 
+  = [ fromMaybe 1e100 (CE.liqCredit (liqMap Map.! liqName))] -- `debug` ("Returning"++ show [ fromMaybe 1e100 (CE.liqCredit (liqMap Map.! liqName))])
+  -- = [ fromMaybe (fromRational (toRational infinity)) (CE.liqCredit (liqMap Map.! liqName))] -- `debug` ("Returning"++ show [ fromMaybe 1e100 (CE.liqCredit (liqMap Map.! liqName))])
 evalExtraSupportBalance d t (W.MultiSupport supports) = concat $ evalExtraSupportBalance d t <$> supports
 
 

--- a/src/Deal/DealAction.hs
+++ b/src/Deal/DealAction.hs
@@ -656,6 +656,13 @@ performAction d t@TestDeal{accounts=accMap} (W.Transfer mLimit an1 an2 mComment)
     accMapAfterDraw = Map.adjust (A.draw transferAmt d txnCom) an1 accMap
     accMapAfterDeposit = Map.adjust (A.deposit transferAmt d txnCom) an2 accMapAfterDraw
 
+performAction d t@TestDeal{accounts=accMap} (W.TransferMultiple sourceAccList targetAcc mComment)
+  = foldr (\(mLimit, sourceAccName) acc -> 
+             performAction d acc (W.Transfer mLimit sourceAccName targetAcc mComment))
+            t
+            sourceAccList  
+
+
 -- ^ book ledger 
 performAction d t@TestDeal{ledgers= Just ledgerM} (W.BookBy (W.ByDS ledger dr ds)) =
   let  

--- a/src/Deal/DealAction.hs
+++ b/src/Deal/DealAction.hs
@@ -573,9 +573,10 @@ performActionWrap d
 
      liqComment = LiquidationProceeds (fromMaybe [] mPid)
      accMapAfterLiq = Map.adjust (A.deposit liqAmt d liqComment) an accMap
-     newRc = rc
+     -- REMOVE future cf
+     newPfInRc = foldr (\k acc -> (Map.adjust (set CF.cashflowTxn []) k acc)) pcf  (Map.keys poolMapToLiq)
    in 
-     (t {accounts = accMapAfterLiq , pool = newPt} , newRc, logs )
+     (t {accounts = accMapAfterLiq , pool = newPt} , rc {runPoolFlow = newPfInRc}, logs )
 
 
 performActionWrap d (t, rc, logs) (W.WatchVal ms dss)

--- a/src/Deal/DealAction.hs
+++ b/src/Deal/DealAction.hs
@@ -611,7 +611,7 @@ performAction d t@TestDeal{accounts=accMap, ledgers = Just ledgerM} (W.Transfer 
   where
     sourceAcc = accMap Map.! an1
     targetAcc = accMap Map.! an2 
-    targetAmt = LD.queryGap (ledgerM Map.! ln) dr 
+    targetAmt = LD.queryGap dr (ledgerM Map.! ln) 
     transferAmt = min (A.accBalance sourceAcc) targetAmt 
  
     accMapAfterDraw = Map.adjust (A.draw transferAmt d (TransferBy an1 an2 (ClearLedger dr ln))) an1 accMap -- `debug` (">>PDL >>Ledger bal"++show d ++ show targetAmt)
@@ -1084,12 +1084,12 @@ performAction d t@TestDeal{bonds=bndMap, ledgers = Just ledgerM } (W.WriteOff (J
   = t {bonds = bndMapUpdated, ledgers = Just newLedgerM}
   where 
     -- writeAmtUnSign = queryDeal t (LedgerBalance lns)
-    writeAmt = sum $ (`LD.queryGap` dr) <$> (ledgerM Map.!) <$> lns
+    writeAmt = sum $ (LD.queryGap dr) <$> (ledgerM Map.!) <$> lns
     writeAmtCapped = min writeAmt $ L.bndBalance $ bndMap Map.! bnd
     bndMapUpdated = Map.adjust ((L.writeOff d writeAmtCapped) . (calcDueInt t d Nothing Nothing)) bnd bndMap
 
-    ledgerList = filter (\l -> LD.queryGap l dr > 0)  $ (ledgerM Map.!) <$> lns
-    (newLedgers,_) = LD.clearLedgersBySeq writeAmtCapped dr d [] ledgerList
+    ledgerList = filter (\l -> LD.queryGap dr l > 0)  $ (ledgerM Map.!) <$> lns
+    (newLedgers,_) = LD.clearLedgersBySeq dr d writeAmtCapped [] ledgerList
     newLedgerMap = lstToMapByFn LD.ledgName newLedgers
     newLedgerM = Map.union newLedgerMap ledgerM
 
@@ -1097,7 +1097,7 @@ performAction d t@TestDeal{bonds=bndMap, ledgers = Just ledgerM } (W.WriteOff (J
 performAction d t@TestDeal{bonds=bndMap, ledgers = Just ledgerM } (W.WriteOff (Just (ClearLedger dr ln)) bnd)
   = t {bonds = bndMapUpdated, ledgers = Just newLedgerM}
   where 
-    writeAmt = LD.queryGap (ledgerM Map.! ln) dr
+    writeAmt = LD.queryGap dr (ledgerM Map.! ln)
     writeAmtCapped = min writeAmt $ L.bndBalance $ bndMap Map.! bnd
     bndMapUpdated = Map.adjust ((L.writeOff d writeAmtCapped) . (calcDueInt t d Nothing Nothing)) bnd bndMap
     newLedgerM = Map.adjust 

--- a/src/Deal/DealBase.hs
+++ b/src/Deal/DealBase.hs
@@ -161,6 +161,7 @@ data DateDesp = FixInterval (Map.Map DateType Date) Period Period
 
 class SPV a where
   getBondsByName :: a -> Maybe [String] -> Map.Map String L.Bond
+  getActiveBonds :: a -> [String] -> [L.Bond]
   getBondBegBal :: a -> String -> Balance
   getBondStmtByName :: a -> Maybe [String] -> Map.Map String (Maybe Statement)
   getFeeByName :: a -> Maybe [String] -> Map.Map String F.Fee
@@ -231,6 +232,12 @@ instance SPV (TestDeal a) where
     = case bns of
          Nothing -> bonds t
          Just _bns -> Map.filterWithKey (\k _ -> S.member k (S.fromList _bns)) (bonds t)
+  
+  getActiveBonds t bns = 
+    let 
+      bnds = (bonds t Map.!) <$> bns
+    in 
+      filter (not . L.isPaidOff) bnds
 
   getBondStmtByName t bns
     = Map.map L.bndStmt bndsM

--- a/src/Deal/DealBase.hs
+++ b/src/Deal/DealBase.hs
@@ -11,7 +11,7 @@ module Deal.DealBase (TestDeal(..),SPV(..),dealBonds,dealFees,dealAccounts,dealP
                      ,getIssuanceStatsConsol,getAllCollectedTxnsList,dealScheduledCashflow
                      ,getPoolIds,getBondByName, UnderlyingDeal(..),dealCashflow, uDealFutureTxn,viewDealAllBonds,DateDesp(..),ActionOnDate(..),OverrideType(..)
                      ,sortActionOnDate,dealBondGroups
-                     ,viewDealBondsByNames,poolTypePool,viewBondsInMap
+                     ,viewDealBondsByNames,poolTypePool,viewBondsInMap,bondGroupsBonds
                      )                      
   where
 import qualified Accounts as A
@@ -263,9 +263,17 @@ instance SPV (TestDeal a) where
                  ResecDeal _ -> True
                  _ -> False
 
+_expandBonds :: Map.Map BondName L.Bond -> [L.Bond]
+_expandBonds bMap = 
+  let 
+    bs = Map.elems bMap
+    view a@(L.Bond {}) = [a]
+    view a@(L.BondGroup bMap) = Map.elems bMap
+  in 
+    concat $ view <$> bs
 
 
-
+-- ^ list all bonds and bond groups in list
 viewDealAllBonds :: TestDeal a -> [L.Bond]
 viewDealAllBonds d = 
     let 
@@ -275,6 +283,7 @@ viewDealAllBonds d =
     in 
        concat $ view <$> bs
 
+-- ^ flatten all bonds/bond groups in a map
 viewBondsInMap :: TestDeal a -> Map.Map String L.Bond
 viewBondsInMap t@TestDeal{ bonds = bndMap }
   = let 
@@ -283,7 +292,7 @@ viewBondsInMap t@TestDeal{ bonds = bndMap }
     in 
       Map.fromList $ zip bndNames bnds
 
-
+-- ^ support bond group
 viewDealBondsByNames :: Ast.Asset a => TestDeal a -> [BondName] -> [L.Bond]
 viewDealBondsByNames _ [] = []
 viewDealBondsByNames t@TestDeal{bonds= bndMap } bndNames
@@ -303,21 +312,27 @@ viewDealBondsByNames t@TestDeal{bonds= bndMap } bndNames
     in 
       bnds ++ bndsFromGrp
 
+-- ^ not support bond group
 dealBonds :: Ast.Asset a => Lens' (TestDeal a) (Map.Map BondName L.Bond)
 dealBonds = lens getter setter 
   where 
     getter d = bonds d 
     setter d newBndMap = d {bonds = newBndMap}
 
+-- ^ get & set bond group only
 dealBondGroups :: Ast.Asset a => Lens' (TestDeal a) (Map.Map BondName L.Bond)
 dealBondGroups = lens getter setter 
   where 
-    getter d = Map.filter 
-                 (\case 
-                   (L.Bond {}) -> False
-                   (L.BondGroup {}) -> True)
-                 (bonds d)
-    setter d newBndMap = d {bonds = newBndMap}
+    getter d = Map.filter (has L._BondGroup) (bonds d)
+    setter d newBndMap = d {bonds = Map.filter (has L._BondGroup) newBndMap}
+
+bondGroupsBonds :: Lens' L.Bond (Map.Map BondName L.Bond)
+bondGroupsBonds = lens getter setter 
+  where 
+    getter (L.BondGroup bMap) = bMap
+    getter _ = Map.empty
+    setter (L.BondGroup _) newBMap = L.BondGroup newBMap
+    setter x _ = x
 
 dealAccounts :: Ast.Asset a => Lens' (TestDeal a) (Map.Map AccountName A.Account) 
 dealAccounts = lens getter setter 

--- a/src/Deal/DealBase.hs
+++ b/src/Deal/DealBase.hs
@@ -11,7 +11,7 @@ module Deal.DealBase (TestDeal(..),SPV(..),dealBonds,dealFees,dealAccounts,dealP
                      ,getIssuanceStatsConsol,getAllCollectedTxnsList,dealScheduledCashflow
                      ,getPoolIds,getBondByName, UnderlyingDeal(..),dealCashflow, uDealFutureTxn,viewDealAllBonds,DateDesp(..),ActionOnDate(..),OverrideType(..)
                      ,sortActionOnDate,dealBondGroups
-                     ,viewDealBondsByNames,poolTypePool
+                     ,viewDealBondsByNames,poolTypePool,viewBondsInMap
                      )                      
   where
 import qualified Accounts as A
@@ -58,12 +58,6 @@ import qualified Types as CF
 import Debug.Trace
 import qualified Control.Lens as P
 debug = flip trace
--- import Data.Aeson.Types (Parser)
--- import qualified Data.HashMap.Strict as HM
--- import Data.Text (unpack)
--- import Control.Monad.IO.Class (liftIO)
-
-
 
 
 data ActionOnDate = EarnAccInt Date AccName              -- ^ sweep bank account interest
@@ -280,6 +274,15 @@ viewDealAllBonds d =
        view a@(L.BondGroup bMap) = Map.elems bMap
     in 
        concat $ view <$> bs
+
+viewBondsInMap :: TestDeal a -> Map.Map String L.Bond
+viewBondsInMap t@TestDeal{ bonds = bndMap }
+  = let 
+      bnds = viewDealAllBonds t 
+      bndNames = L.bndName <$> bnds
+    in 
+      Map.fromList $ zip bndNames bnds
+
 
 viewDealBondsByNames :: Ast.Asset a => TestDeal a -> [BondName] -> [L.Bond]
 viewDealBondsByNames _ [] = []

--- a/src/Deal/DealQuery.hs
+++ b/src/Deal/DealQuery.hs
@@ -696,7 +696,12 @@ testPre d t p =
     If cmp s amt -> toCmp cmp (queryDeal t (ps s))  amt
     IfRate cmp s amt -> toCmp cmp (queryDealRate t (ps s)) amt
     IfInt cmp s amt -> toCmp cmp (queryDealInt t (ps s) d) amt
+    
+    -- IfIntBetween cmp1 s1 cmp2 s2 amt -> toCmp cmp1 (queryDealInt t (ps s1) d) amt && toCmp cmp2 (queryDealInt t (ps s2) d) amt
+
     IfDate cmp _d -> toCmp cmp d _d
+    -- IfDateBetween cmp1 d1 cmp2 d2 -> toCmp cmp1 d d1 && toCmp cmp2 d d2
+
     IfCurve cmp s _ts -> toCmp cmp (queryDeal t (ps s)) (fromRational (getValByDate _ts Inc d))
     IfRateCurve cmp s _ts -> toCmp cmp (queryDealRate t (ps s)) (fromRational (getValByDate _ts Inc d))
     IfBool s True -> queryDealBool t s d
@@ -705,6 +710,7 @@ testPre d t p =
     IfRate2 cmp s1 s2 -> toCmp cmp (queryDealRate t (ps s1)) (queryDealRate t (ps s2))
     IfInt2 cmp s1 s2 -> toCmp cmp (queryDealInt t (ps s1) d) (queryDealInt t (ps s2) d)
     IfDealStatus st -> status t == st   --  `debug` ("current date"++show d++">> stutus"++show (status t )++"=="++show st)
+    
     Always b -> b
     IfNot _p -> not $ testPre d t _p
     where 

--- a/src/Deal/DealQuery.hs
+++ b/src/Deal/DealQuery.hs
@@ -694,7 +694,9 @@ testPre d t p =
     IfZero s -> queryDeal t s == 0.0 -- `debug` ("S->"++show(s)++">>"++show((queryDeal t s)))
     
     If cmp s amt -> toCmp cmp (queryDeal t (ps s))  amt
+    
     IfRate cmp s amt -> toCmp cmp (queryDealRate t (ps s)) amt
+
     IfInt cmp s amt -> toCmp cmp (queryDealInt t (ps s) d) amt
     
     -- IfIntBetween cmp1 s1 cmp2 s2 amt -> toCmp cmp1 (queryDealInt t (ps s1) d) amt && toCmp cmp2 (queryDealInt t (ps s2) d) amt

--- a/src/Deal/DealQuery.hs
+++ b/src/Deal/DealQuery.hs
@@ -292,6 +292,7 @@ queryDeal t@TestDeal{accounts=accMap, bonds=bndMap, fees=feeMap, ledgers=ledgerM
     
     AccBalance ans -> sum $ A.accBalance . (accMap Map.!) <$> ans
     
+    -- ^ negatave -> credit balance , postive -> debit balance
     LedgerBalance ans ->
       case ledgerM of 
         Nothing -> error ("No ledgers were modeled , failed to find ledger:"++show ans )

--- a/src/Deal/DealQuery.hs
+++ b/src/Deal/DealQuery.hs
@@ -310,11 +310,6 @@ queryDeal t@TestDeal{accounts=accMap, bonds=bndMap, fees=feeMap, ledgers=ledgerM
         $ (-) (sum $ calcTargetAmount t d . (accMap Map.!) <$> ans ) (queryDeal t (AccBalance ans)) 
 
     FutureCurrentPoolBalance mPns ->
-      -- let 
-      --   -- TOBE FIX
-      --   ltc = getLatestCollectFrame t mPns
-      -- in 
-      --   sum $ maybe 0 CF.mflowBalance <$> ltc 
       case (mPns,pt) of 
         (Nothing,SoloPool p) -> Pl.getIssuanceField p RuntimeCurrentPoolBalance
         (Nothing,MultiPool pm ) -> queryDeal t (FutureCurrentPoolBalance (Just $ Map.keys pm))
@@ -325,7 +320,7 @@ queryDeal t@TestDeal{accounts=accMap, bonds=bndMap, fees=feeMap, ledgers=ledgerM
             in 
               sum $ Map.elems $ Map.map (`Pl.getIssuanceField` RuntimeCurrentPoolBalance) m 
           else 
-            error $ "Failed to find pool balance" ++ show mPns ++ " from deal "++ show pt
+            error $ "Failed to find pool balance" ++ show pids ++ " from deal "++ show (Map.keys pm)
 
 
 

--- a/src/Deal/DealValidation.hs
+++ b/src/Deal/DealValidation.hs
@@ -196,8 +196,9 @@ validateAction ((W.BuyAssetFrom _ _ accName mRPoolName mPid):as) rs accKeys bndK
   | Set.notMember (fromMaybe PoolConsol mPid) poolKeys = validateAction as (rs ++ [ErrorMsg (show mPid++" not in "++show poolKeys)]) accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
   | otherwise = validateAction as rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
 
-validateAction ((W.LiquidatePool _ accName):as) rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
+validateAction ((W.LiquidatePool _ accName mPids):as) rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
   | Set.notMember accName accKeys = validateAction as (rs ++ [ErrorMsg (accName++" not in "++show accKeys)]) accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
+  | isJust mPids && not (Set.isSubsetOf (Set.fromList (fromMaybe [] mPids)) poolKeys) = validateAction as (rs ++ [ErrorMsg (show mPids++" not in "++show poolKeys)]) accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
   | otherwise = validateAction as rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
 
 validateAction ((W.LiqSupport _ liqName _ accName):as) rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys

--- a/src/Deal/DealValidation.hs
+++ b/src/Deal/DealValidation.hs
@@ -355,7 +355,8 @@ extractRequiredRevolvingPool t@TestDeal{waterfall = waterfallM} =
 
 
 validateReq :: (IR.UseRate a,P.Asset a) => TestDeal a -> AP.NonPerfAssumption -> (Bool,[ResultComponent])
-validateReq t@TestDeal{accounts = accMap, fees = feeMap} assump@A.NonPerfAssumption{A.interest = intM, A.issueBondSchedule = mIssuePlan, A.revolving = mRevolvingAssump} 
+validateReq t@TestDeal{accounts = accMap, fees = feeMap} 
+            assump@A.NonPerfAssumption{A.interest = intM, A.issueBondSchedule = mIssuePlan, A.revolving = mRevolvingAssump} 
   = let 
       ratesRequired = extractRequiredRates t
       ratesSupplied = case intM of 

--- a/src/Deal/DealValidation.hs
+++ b/src/Deal/DealValidation.hs
@@ -454,7 +454,6 @@ validatePreRun t@TestDeal{waterfall=waterfallM
 
       -- val on deal status and deal dates
       statusCheck (PreClosing _) PreClosingDates {} = [] 
-      statusCheck _ PreClosingDates {} = [ErrorMsg "Deal is using PreClosing Dates but its status is not PreClosing"]
       statusCheck (PreClosing _) _ = [ErrorMsg "Deal is in PreClosing status but it is not using preClosing dates"]
       statusCheck _ _ = []
 

--- a/src/Liability.hs
+++ b/src/Liability.hs
@@ -13,7 +13,7 @@ module Liability
   ,buildRateResetDates,isAdjustble,StepUp(..),isStepUp,getDayCountFromInfo
   ,calcWalBond,patchBondFactor,fundWith,writeOff,InterestOverInterestType(..)
   ,getCurBalance,setBondOrigDate
-  ,bndOriginInfoLens,bndIntLens,getBeginRate)
+  ,bndOriginInfoLens,bndIntLens,getBeginRate,_Bond,_BondGroup)
   where
 
 import Language.Haskell.TH
@@ -497,6 +497,9 @@ instance IR.UseRate Bond where
      
 makeLensesFor [("bndType","bndTypeLens"),("bndOriginInfo","bndOriginInfoLens"),("bndInterestInfo","bndIntLens"),("bndStmt","bndStmtLens")] ''Bond
 makeLensesFor [("bndOriginDate","bndOriginDateLens"),("bndOriginBalance","bndOriginBalanceLens"),("bndOriginRate","bndOriginRateLens")] ''OriginalInfo
+
+makePrisms ''Bond
+
 
 $(deriveJSON defaultOptions ''InterestOverInterestType)
 $(deriveJSON defaultOptions ''InterestInfo)

--- a/src/Liability.hs
+++ b/src/Liability.hs
@@ -116,8 +116,6 @@ getBeginRate (FloorRate a  _ ) = getBeginRate a
 getBeginRate (WithIoI a _) = getBeginRate a
 getBeginRate InterestByYield {} = 0.0
 
-
-
 data StepUp = PassDateSpread Date Spread                   -- ^ add a spread on a date and effective afterwards
             | PassDateLadderSpread Date Spread RateReset   -- ^ add a spread on the date pattern
             deriving (Show, Eq, Generic, Ord, Read)
@@ -205,6 +203,18 @@ payInt d amt bnd@(Bond bn bt oi iinfo _ bal r duePrin dueInt dueIoI dueIntDate l
     newDueIoI = dueIoI - head rs
     newDue = dueInt - rs !! 1 -- `debug` ("Avail fund"++ show amt ++" int paid out plan"++ show rs)
     newStmt = S.appendStmt stmt (BondTxn d bal amt 0 r amt newDue newDueIoI Nothing (S.PayInt [bn])) -- `debug` ("date after"++ show d++"due "++show newDueIoI++">>"++show newDue)
+
+payIntBySeq :: Date -> Amount -> [Bond] -> [Bond] -> ([Bond],Amount)
+payIntBySeq d amt bondsPaid [] = (bondsPaid, amt)
+payIntBySeq d 0 bondsPaid bondsToPaid = (bondsPaid ++ bondsToPaid, 0)
+payIntBySeq d amt bondsPaid (b:bondsToPaid)
+  = let 
+      intD = getDueInt b
+      actPaidOut = min amt intD
+      remains = amt - actPaidOut
+    in 
+      payIntBySeq d remains (payInt d actPaidOut b:bondsPaid) bondsToPaid
+
 
 payYield :: Date -> Amount -> Bond -> Bond 
 payYield d amt bnd@(Bond bn bt oi iinfo _ bal r duePrin dueInt dueIoI dueIntDate lpayInt lpayPrin stmt)

--- a/src/Pool.hs
+++ b/src/Pool.hs
@@ -156,6 +156,12 @@ calcLiquidationAmount (BalanceFactor currentFactor defaultFactor ) pool d
             _ -> (mulBR (CF.mflowBalance (last earlierTxns)) currentFactor) + (mulBR currentCumulativeDefaultBal defaultFactor)
             -- TODO need to check if missing last row
 
+
+-- TODO: check futureCf is future CF or not
+-- | pricing via future schedule cashflow
+-- | pricing via predefined risk adjust cashflow
+-- | pricing via user define risk adjust cashflow
+-- TODO: in revolving buy future schedule cashflow should be updated as well
 calcLiquidationAmount (PV discountRate recoveryPct) pool d 
   = case futureCf pool of
       Nothing -> 0 

--- a/src/Pool.hs
+++ b/src/Pool.hs
@@ -84,14 +84,16 @@ poolIssuanceStat = lens getter setter
     getter p =  fromMaybe Map.empty $ issuanceStat p
     setter p m = case issuanceStat p of
                     Nothing -> p {issuanceStat = Just m}
-                    Just m -> p {issuanceStat = Just m}
+                    Just _ -> p {issuanceStat = Just m}
+
 
 -- | get stats of pool 
 getIssuanceField :: Pool a -> CutoffFields -> Balance
 getIssuanceField p@Pool{issuanceStat = Just m} s
   = case Map.lookup s m of
       Just r -> r
-      Nothing -> error ("Failed to lookup "++show s++" in stats "++show m)
+      -- Nothing -> error ("Failed to lookup "++show s++" in stats "++show m)
+      Nothing -> 0.0
 getIssuanceField Pool{issuanceStat = Nothing} _ 
   = error "There is no pool stats"
 

--- a/src/Reports.hs
+++ b/src/Reports.hs
@@ -60,12 +60,15 @@ getItemBalance :: BookItem -> Balance
 getItemBalance (Item _ bal) = bal
 getItemBalance (ParentItem _ items) = sum $ getItemBalance <$> items
 
+
+-- TODO fix pool bablance
 buildBalanceSheet :: P.Asset a => TestDeal a -> Date -> BalanceSheetReport
 buildBalanceSheet t@TestDeal{ pool = pool, bonds = bndMap , fees = feeMap , liqProvider = liqMap, rateSwap = rsMap } d 
     = BalanceSheetReport {asset=ast,liability=liab,equity=eqty,reportDate=d}
     where 
         ---accured interest
         accM = [ Item accName accBal | (accName,accBal) <- Map.toList $ Map.map A.accBalance (accounts t) ]
+        -- TODO Fix all pool
         consoleCF = getAllCollectedFrame t (Just [PoolConsol]) Map.! PoolConsol
         (performingBal,dBal,rBal) = case consoleCF of
                                       Nothing -> let 

--- a/src/Stmt.hs
+++ b/src/Stmt.hs
@@ -212,7 +212,7 @@ getFlow comment =
       PayFeeYield _ -> Outflow
       Transfer _ _ -> Interflow 
       PoolInflow _ _ -> Inflow
-      LiquidationProceeds -> Inflow
+      LiquidationProceeds _ -> Inflow
       LiquidationSupport _ -> Inflow
       LiquidationDraw -> Noneflow
       LiquidationRepay -> Outflow

--- a/src/Stmt.hs
+++ b/src/Stmt.hs
@@ -112,7 +112,7 @@ emptyTxn EntryTxn {} d = EntryTxn d 0 0 Empty
 emptyTxn TrgTxn {} d = TrgTxn d False Empty
 
 isEmptyTxn :: Txn -> Bool
-isEmptyTxn (BondTxn _ 0 0 0 _ 0 0 0 _ _) = True
+isEmptyTxn (BondTxn _ 0 0 0 _ 0 0 0 _ Empty) = True
 isEmptyTxn (AccTxn _ 0 0 Empty) = True
 isEmptyTxn (ExpTxn _ 0 0 0 Empty) = True
 isEmptyTxn (SupportTxn _ Nothing 0 0 0 0 Empty) = True

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -366,7 +366,7 @@ data DealStatus = DealAccelerated (Maybe Date)      -- ^ Deal is accelerated sta
                 | Amortizing                        -- ^ Deal is amortizing 
                 | Revolving                         -- ^ Deal is revolving
                 | PreClosing DealStatus             -- ^ Deal is not closed, but has a closing date
-                | Warehousing DealStatus              -- ^ Deal is not closed, but closing date is not determined yet
+                | Warehousing (Maybe DealStatus)    -- ^ Deal is not closed, but closing date is not determined yet
                 | Called                            -- ^ Deal is called
                 | Ended                             -- ^ Deal is marked as closed
                 deriving (Show,Ord,Eq,Read, Generic)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -807,7 +807,7 @@ instance ToJSON TxnComment where
   toJSON (Transfer an1 an2) =  String $ T.pack $ "<Transfer:"++ an1 ++","++ an2++">"
   toJSON (TransferBy an1 an2 limit) =  String $ T.pack $ "<TransferBy:"++ an1 ++","++ an2++","++show limit++">"
   toJSON (PoolInflow mPids ps) =  String $ T.pack $ "<Pool"++ maybe "" (intercalate "|" . (show <$>)) mPids ++":"++ show ps++">"
-  toJSON (LiquidationProceeds pids) =  String $ T.pack $ "<Liquidation:"++ (intercalate "," (show <$> pids)) ++">"
+  toJSON (LiquidationProceeds pids) =  String $ T.pack $ "<Liquidation:"++ listToStrWithComma (show <$> pids) ++">"
   toJSON (UsingDS ds) =  String $ T.pack $ "<DS:"++ show ds++">"
   toJSON BankInt =  String $ T.pack $ "<BankInterest:>"
   toJSON Empty =  String $ T.pack $ "" 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -475,7 +475,7 @@ data DealStats = CurrentBondBalance
                | DealIssuanceBalance (Maybe [PoolId])
                | CurrentPoolBorrowerNum (Maybe [PoolId])
                | ProjCollectPeriodNum
-               | BondFactor
+               | BondFactor     -- ^ TODO implement a specific bond
                | PoolFactor (Maybe [PoolId])
                | BondWaRate [BondName]
                | UseCustomData String
@@ -642,6 +642,7 @@ data CutoffFields = IssuanceBalance      -- ^ pool issuance balance
                   | HistoryLoss          -- ^ cumulative loss/write-off balance
                   | HistoryCash          -- ^ cumulative cash
                   | AccruedInterest      -- ^ accrued interest at closing
+                  | RuntimeCurrentPoolBalance   -- ^ current pool balance
                   deriving (Show,Ord,Eq,Read,Generic)
 
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -824,6 +824,9 @@ instance ToJSON TxnComment where
   toJSON (IssuanceProceeds nb) = String $ T.pack $ "<IssuanceProceeds:"++nb++">"
   toJSON (Tag cmt) = String $ T.pack $ "<Tag:"++cmt++">"
   toJSON (TxnComments tcms) = Array $ V.fromList $ map toJSON tcms
+  toJSON (PayGroupInt bns) = String $ T.pack $ "<PayGroupInt:"++ listToStrWithComma bns ++ ">"
+  toJSON (PayGroupPrin bns) = String $ T.pack $ "<PayGroupPrin:"++ listToStrWithComma bns ++ ">"
+  toJSON x = error $ "Not support for toJSON for "++show x
 
 instance FromJSON TxnComment where
     parseJSON = withText "Empty" parseTxn

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -418,6 +418,8 @@ data ActionType = ActionResetRate  -- ^ reset interest rate from curve
 data TxnComment = PayInt [BondName]
                 | PayYield BondName 
                 | PayPrin [BondName] 
+                | PayGroupPrin [BondName]
+                | PayGroupInt [BondName]
                 | WriteOff BondName Balance
                 | FundWith BondName Balance
                 | PayPrinResidual [BondName] 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -584,7 +584,8 @@ data Limit = DuePct Rate            -- ^ up to % of total amount due
            | DueCapAmt Balance      -- ^ up to $ amount 
            | KeepBalAmt DealStats   -- ^ pay till a certain amount remains in an account
            | DS DealStats           -- ^ transfer with limit described by a `DealStats`
-           | ClearLedger String     -- ^ when transfer, clear the ledger by transfer amount
+           | ClearLedger BookDirection String     -- ^ when transfer, clear the ledger by transfer amount
+           | ClearLedgerBySeq BookDirection [String]  -- ^ clear a direction to a sequence of ledgers
            | BookLedger String      -- ^ when transfer, book the ledger by the transfer amount
            | RemainBalPct Rate      -- ^ pay till remain balance equals to a percentage of `stats`
            | TillTarget             -- ^ transfer amount which make target account up reach reserve balanace

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -11,7 +11,7 @@ module Util
     ,maximum',minimum',roundingBy,roundingByM
     ,floorWith,slice,toPeriodRateByInterval, dropLastN, zipBalTs
     ,lastOf,findBox
-    ,safeDivide,lstToMapByFn,paySequentially
+    ,safeDivide,lstToMapByFn,paySequentially,payProRata
     -- for debug
     ,zyj
     )
@@ -334,6 +334,20 @@ paySequentially d amt getDueAmt payFn paidList (l:tobePaidList)
       paidL = payFn actualPaidOut l
     in 
       paySequentially d remainAmt getDueAmt payFn (paidL:paidList) tobePaidList
+
+payProRata :: Date -> Amount -> (a->Balance) -> (Amount->a->a) -> [a] -> ([a],Amount)
+payProRata d amt getDueAmt payFn tobePaidList
+  = let 
+      dueAmts = getDueAmt <$> tobePaidList
+      totalDueAmt = sum  dueAmts
+      actualPaidOut = min amt totalDueAmt
+      remainAmt = amt - actualPaidOut
+
+      allocAmt = prorataFactors dueAmts actualPaidOut
+
+      paidList = [ payFn amt l | (amt,l) <- zip allocAmt tobePaidList ]
+    in 
+      (paidList, remainAmt)
 
 ----- DEBUG/PRINT
 -- z y j : stands for chinese Zhao Yao Jing ,which is a mirror reveals the devil 

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -11,7 +11,7 @@ module Util
     ,maximum',minimum',roundingBy,roundingByM
     ,floorWith,slice,toPeriodRateByInterval, dropLastN, zipBalTs
     ,lastOf,findBox
-    ,safeDivide,lstToMapByFn
+    ,safeDivide,lstToMapByFn,paySequentially
     -- for debug
     ,zyj
     )
@@ -321,7 +321,7 @@ lstToMapByFn fn lst =
   in 
     M.fromList $ zip ks lst
 
-paySequentially :: Date -> Amount -> (a->Balance) -> (a->Amount->a) -> [a] -> [a] -> ([a],Amount)
+paySequentially :: Date -> Amount -> (a->Balance) -> (Amount->a->a) -> [a] -> [a] -> ([a],Amount)
 paySequentially d amt getDueAmt payFn paidList []
   = (reverse paidList, amt)
 paySequentially d 0 getDueAmt payFn paidList tobePaidList
@@ -331,7 +331,7 @@ paySequentially d amt getDueAmt payFn paidList (l:tobePaidList)
       dueAmt = getDueAmt l
       actualPaidOut = min amt dueAmt 
       remainAmt = amt - actualPaidOut
-      paidL = payFn l actualPaidOut
+      paidL = payFn actualPaidOut l
     in 
       paySequentially d remainAmt getDueAmt payFn (paidL:paidList) tobePaidList
 

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -11,12 +11,13 @@ module Util
     ,maximum',minimum',roundingBy,roundingByM
     ,floorWith,slice,toPeriodRateByInterval, dropLastN, zipBalTs
     ,lastOf,findBox
-    ,safeDivide,lstToMapByFn,paySequentially,payProRata
+    ,safeDivide,lstToMapByFn,paySequentially,payProRata,mapWithinMap
     -- for debug
     ,zyj
     )
     where
 import qualified Data.Time as T
+import qualified Data.Map as Map
 import Data.List
 import Data.Fixed
 import Data.Ratio ((%))
@@ -360,6 +361,9 @@ payProRata d amt getDueAmt payFn tobePaidList
       paidList = [ payFn amt l | (amt,l) <- zip allocAmt tobePaidList ]
     in 
       (paidList, remainAmt)
+
+mapWithinMap :: Ord k => (a -> a) -> [k] -> Map.Map k a -> Map.Map k a  
+mapWithinMap fn ks m = foldr (Map.adjust fn) m ks
 
 ----- DEBUG/PRINT
 -- z y j : stands for chinese Zhao Yao Jing ,which is a mirror reveals the devil 

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -11,7 +11,7 @@ module Util
     ,maximum',minimum',roundingBy,roundingByM
     ,floorWith,slice,toPeriodRateByInterval, dropLastN, zipBalTs
     ,lastOf,findBox
-    ,safeDivide
+    ,safeDivide,lstToMapByFn
     -- for debug
     ,zyj
     )
@@ -313,6 +313,13 @@ findBox (Exc,Exc) x ((l,h):xs)
 safeDivide :: RealFloat a => a -> a -> a 
 safeDivide _ 0 = infinity
 safeDivide x y = x / y
+
+lstToMapByFn :: (a -> String) -> [a] -> M.Map String a 
+lstToMapByFn fn lst =
+  let 
+    ks = fn <$> lst 
+  in 
+    M.fromList $ zip ks lst
 
 
 ----- DEBUG/PRINT

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -321,6 +321,19 @@ lstToMapByFn fn lst =
   in 
     M.fromList $ zip ks lst
 
+paySequentially :: Date -> Amount -> (a->Balance) -> (a->Amount->a) -> [a] -> [a] -> ([a],Amount)
+paySequentially d amt getDueAmt payFn paidList []
+  = (reverse paidList, amt)
+paySequentially d 0 getDueAmt payFn paidList tobePaidList
+  = (reverse (paidList++tobePaidList), 0)
+paySequentially d amt getDueAmt payFn paidList (l:tobePaidList)
+  = let 
+      dueAmt = getDueAmt l
+      actualPaidOut = min amt dueAmt 
+      remainAmt = amt - actualPaidOut
+      paidL = payFn l actualPaidOut
+    in 
+      paySequentially d remainAmt getDueAmt payFn (paidL:paidList) tobePaidList
 
 ----- DEBUG/PRINT
 -- z y j : stands for chinese Zhao Yao Jing ,which is a mirror reveals the devil 

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -100,6 +100,11 @@ getValByDate (FloatCurve dps) Exc d
       Just (TsPoint _d v) -> toRational v  -- `debug` ("Getting rate "++show(_d)++show(v))
       Nothing -> 0              -- `debug` ("Getting 0 ")
 
+getValByDate (FloatCurve dps) Inc d
+  = case find (\(TsPoint _d _) -> d >= _d) (reverse dps)  of 
+      Just (TsPoint _d v) -> toRational v  -- `debug` ("Getting rate "++show(_d)++show(v))
+      Nothing -> 0              -- `debug` ("Getting 0 ")
+
 getValByDate (IRateCurve dps) Exc d
   = case find (\(TsPoint _d _) -> d > _d) (reverse dps)  of
       Just (TsPoint _d v) -> toRational v  -- `debug` ("Getting rate "++show(_d)++show(v))
@@ -189,9 +194,16 @@ zipTs ds rs = FloatCurve [ TsPoint d r | (d,r) <- zip ds rs ]
 zipBalTs :: [Date] -> [Balance] -> Ts
 zipBalTs ds rs = BalanceCurve [ TsPoint d r | (d,r) <- zip ds rs ]
 
+-- ^ multiply 1st Ts with values from 2nd Ts
 multiplyTs :: CutoffType -> Ts -> Ts -> Ts
 multiplyTs ct (FloatCurve ts1) ts2
   = FloatCurve [(TsPoint d (v * (getValByDate ts2 ct d))) | (TsPoint d v) <- ts1 ] 
+
+multiplyTs ct (IRateCurve ts1) ts2
+  = IRateCurve [(TsPoint d (v * (fromRational (getValByDate ts2 ct d)))) | (TsPoint d v) <- ts1 ] 
+
+multiplyTs c a b = error  $ "Failed to match : multiplyTs"++ show c ++ show a ++ show b
+
 
 -- | swap a value in list with index supplied
 replace :: [a] -> Int -> a -> [a]

--- a/src/Waterfall.hs
+++ b/src/Waterfall.hs
@@ -90,7 +90,7 @@ data Action = Transfer (Maybe Limit) AccountName AccountName (Maybe TxnComment)
             -- Pool/Asset change
             | BuyAsset (Maybe Limit) PricingMethod AccountName (Maybe PoolId)                       -- ^ buy asset from revolving assumptions using funds from account
             | BuyAssetFrom (Maybe Limit) PricingMethod AccountName (Maybe String) (Maybe PoolId)    -- ^ buy asset from specific pool, with revolving assumptions using funds from account
-            | LiquidatePool PricingMethod AccountName                                               -- ^ sell all assets and deposit proceeds to account
+            | LiquidatePool PricingMethod AccountName  (Maybe [PoolId])                               -- ^ sell all assets and deposit proceeds to account
             -- Liquidation support
             | LiqSupport (Maybe Limit) CE.LiquidityProviderName CE.LiqDrawType AccountName  -- ^ draw credit and deposit to account/fee/bond interest/principal
             | LiqRepay (Maybe Limit) CE.LiqRepayType AccountName CE.LiquidityProviderName   -- ^ repay liquidity facility

--- a/src/Waterfall.hs
+++ b/src/Waterfall.hs
@@ -85,6 +85,7 @@ data Action = Transfer (Maybe Limit) AccountName AccountName (Maybe TxnComment)
             | AccrueAndPayIntGroup (Maybe Limit) AccountName BondName PayOrderBy (Maybe ExtraSupport) 
             -- Bond - Balance
             | WriteOff (Maybe Limit) BondName
+            | WriteOffBySeq (Maybe Limit) [BondName]
             | FundWith (Maybe Limit) AccountName BondName             -- ^ extra more funds from bond and deposit cash to account
             -- Pool/Asset change
             | BuyAsset (Maybe Limit) PricingMethod AccountName (Maybe PoolId)                       -- ^ buy asset from revolving assumptions using funds from account

--- a/src/Waterfall.hs
+++ b/src/Waterfall.hs
@@ -52,7 +52,10 @@ data PayOrderBy = ByName
                 deriving (Show,Generic,Eq,Ord)
 
 
-data Action = Transfer (Maybe Limit) AccountName AccountName (Maybe TxnComment)
+data Action =
+            -- Accounts 
+            Transfer (Maybe Limit) AccountName AccountName (Maybe TxnComment)
+            | TransferMultiple [(Maybe Limit, AccountName)] AccountName (Maybe TxnComment)
             -- Fee
             | CalcFee [FeeName]                                                            -- ^ calculate fee due amount in the fee names
             | PayFee (Maybe Limit) AccountName [FeeName] (Maybe ExtraSupport)              -- ^ pay fee with cash from account with optional limit or extra support

--- a/src/Waterfall.hs
+++ b/src/Waterfall.hs
@@ -90,7 +90,8 @@ data Action = Transfer (Maybe Limit) AccountName AccountName (Maybe TxnComment)
             -- Pool/Asset change
             | BuyAsset (Maybe Limit) PricingMethod AccountName (Maybe PoolId)                       -- ^ buy asset from revolving assumptions using funds from account
             | BuyAssetFrom (Maybe Limit) PricingMethod AccountName (Maybe String) (Maybe PoolId)    -- ^ buy asset from specific pool, with revolving assumptions using funds from account
-            | LiquidatePool PricingMethod AccountName  (Maybe [PoolId])                               -- ^ sell all assets and deposit proceeds to account
+            | LiquidatePool PricingMethod AccountName  (Maybe [PoolId])                             -- ^ sell all assets and deposit proceeds to account
+            -- TODO include a limit for LIquidatePool
             -- Liquidation support
             | LiqSupport (Maybe Limit) CE.LiquidityProviderName CE.LiqDrawType AccountName  -- ^ draw credit and deposit to account/fee/bond interest/principal
             | LiqRepay (Maybe Limit) CE.LiqRepayType AccountName CE.LiquidityProviderName   -- ^ repay liquidity facility

--- a/swagger.json
+++ b/swagger.json
@@ -18562,7 +18562,7 @@
             "name": "BSD 3"
         },
         "title": "Hastructure API",
-        "version": "0.29.12"
+        "version": "0.29.13"
     },
     "openapi": "3.0.0",
     "paths": {

--- a/swagger.json
+++ b/swagger.json
@@ -18286,7 +18286,7 @@
             "name": "BSD 3"
         },
         "title": "Hastructure API",
-        "version": "0.29.5"
+        "version": "0.29.6"
     },
     "openapi": "3.0.0",
     "paths": {

--- a/swagger.json
+++ b/swagger.json
@@ -18562,7 +18562,7 @@
             "name": "BSD 3"
         },
         "title": "Hastructure API",
-        "version": "0.29.10"
+        "version": "0.29.11"
     },
     "openapi": "3.0.0",
     "paths": {

--- a/swagger.json
+++ b/swagger.json
@@ -18562,7 +18562,7 @@
             "name": "BSD 3"
         },
         "title": "Hastructure API",
-        "version": "0.29.11"
+        "version": "0.29.12"
     },
     "openapi": "3.0.0",
     "paths": {

--- a/swagger.json
+++ b/swagger.json
@@ -18031,6 +18031,12 @@
                     },
                     {
                         "properties": {
+                            "contents": {
+                                "items": {
+                                    "$ref": "#/components/schemas/PoolId"
+                                },
+                                "type": "array"
+                            },
                             "tag": {
                                 "enum": [
                                     "LiquidationProceeds"
@@ -18039,7 +18045,8 @@
                             }
                         },
                         "required": [
-                            "tag"
+                            "tag",
+                            "contents"
                         ],
                         "title": "LiquidationProceeds",
                         "type": "object"
@@ -18555,7 +18562,7 @@
             "name": "BSD 3"
         },
         "title": "Hastructure API",
-        "version": "0.29.9"
+        "version": "0.29.10"
     },
     "openapi": "3.0.0",
     "paths": {

--- a/swagger.json
+++ b/swagger.json
@@ -129,6 +129,51 @@
                     {
                         "properties": {
                             "contents": {
+                                "items": [
+                                    {
+                                        "items": {
+                                            "items": [
+                                                {
+                                                    "$ref": "#/components/schemas/Limit"
+                                                },
+                                                {
+                                                    "type": "string"
+                                                }
+                                            ],
+                                            "maxItems": 2,
+                                            "minItems": 2,
+                                            "type": "array"
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/TxnComment"
+                                    }
+                                ],
+                                "maxItems": 3,
+                                "minItems": 3,
+                                "type": "array"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "TransferMultiple"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "title": "TransferMultiple",
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contents": {
                                 "items": {
                                     "type": "string"
                                 },
@@ -18562,7 +18607,7 @@
             "name": "BSD 3"
         },
         "title": "Hastructure API",
-        "version": "0.29.13"
+        "version": "0.29.15"
     },
     "openapi": "3.0.0",
     "paths": {

--- a/swagger.json
+++ b/swagger.json
@@ -9943,6 +9943,38 @@
                     {
                         "properties": {
                             "contents": {
+                                "items": [
+                                    {
+                                        "$ref": "#/components/schemas/BookDirection"
+                                    },
+                                    {
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                ],
+                                "maxItems": 2,
+                                "minItems": 2,
+                                "type": "array"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "ClearLedgerBySeq"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "title": "ClearLedgerBySeq",
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contents": {
                                 "type": "string"
                             },
                             "tag": {
@@ -14779,6 +14811,47 @@
                         ],
                         "title": "MultiRunAssumpReq",
                         "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contents": {
+                                "items": [
+                                    {
+                                        "additionalProperties": {
+                                            "$ref": "#/components/schemas/DealType"
+                                        },
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": {
+                                            "$ref": "#/components/schemas/ApplyAssumptionType"
+                                        },
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": {
+                                            "$ref": "#/components/schemas/NonPerfAssumption"
+                                        },
+                                        "type": "object"
+                                    }
+                                ],
+                                "maxItems": 3,
+                                "minItems": 3,
+                                "type": "array"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "MultiComboReq"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "title": "MultiComboReq",
+                        "type": "object"
                     }
                 ]
             },
@@ -18286,7 +18359,7 @@
             "name": "BSD 3"
         },
         "title": "Hastructure API",
-        "version": "0.29.6"
+        "version": "0.29.8"
     },
     "openapi": "3.0.0",
     "paths": {
@@ -18417,6 +18490,85 @@
                                     ],
                                     "maxItems": 4,
                                     "minItems": 4,
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "description": "Invalid `body`"
+                    }
+                }
+            }
+        },
+        "/runDealByCombo": {
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json;charset=utf-8": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RunDealReq"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json;charset=utf-8": {
+                                "schema": {
+                                    "items": {
+                                        "items": [
+                                            {
+                                                "items": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "string"
+                                                    }
+                                                ],
+                                                "maxItems": 3,
+                                                "minItems": 3,
+                                                "type": "array"
+                                            },
+                                            {
+                                                "items": [
+                                                    {
+                                                        "$ref": "#/components/schemas/DealType"
+                                                    },
+                                                    {
+                                                        "additionalProperties": {
+                                                            "$ref": "#/components/schemas/CashFlowFrame"
+                                                        },
+                                                        "type": "object"
+                                                    },
+                                                    {
+                                                        "items": {
+                                                            "$ref": "#/components/schemas/ResultComponent"
+                                                        },
+                                                        "type": "array"
+                                                    },
+                                                    {
+                                                        "additionalProperties": {
+                                                            "$ref": "#/components/schemas/PriceResult"
+                                                        },
+                                                        "type": "object"
+                                                    }
+                                                ],
+                                                "maxItems": 4,
+                                                "minItems": 4,
+                                                "type": "array"
+                                            }
+                                        ],
+                                        "maxItems": 2,
+                                        "minItems": 2,
+                                        "type": "array"
+                                    },
                                     "type": "array"
                                 }
                             }

--- a/swagger.json
+++ b/swagger.json
@@ -18286,7 +18286,7 @@
             "name": "BSD 3"
         },
         "title": "Hastructure API",
-        "version": "0.29.4"
+        "version": "0.29.5"
     },
     "openapi": "3.0.0",
     "paths": {

--- a/swagger.json
+++ b/swagger.json
@@ -18555,7 +18555,7 @@
             "name": "BSD 3"
         },
         "title": "Hastructure API",
-        "version": "0.29.8"
+        "version": "0.29.9"
     },
     "openapi": "3.0.0",
     "paths": {

--- a/swagger.json
+++ b/swagger.json
@@ -1051,6 +1051,38 @@
                                         "$ref": "#/components/schemas/Limit"
                                     },
                                     {
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                ],
+                                "maxItems": 2,
+                                "minItems": 2,
+                                "type": "array"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "WriteOffBySeq"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "title": "WriteOffBySeq",
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contents": {
+                                "items": [
+                                    {
+                                        "$ref": "#/components/schemas/Limit"
+                                    },
+                                    {
                                         "type": "string"
                                     },
                                     {
@@ -1157,10 +1189,16 @@
                                     },
                                     {
                                         "type": "string"
+                                    },
+                                    {
+                                        "items": {
+                                            "$ref": "#/components/schemas/PoolId"
+                                        },
+                                        "type": "array"
                                     }
                                 ],
-                                "maxItems": 2,
-                                "minItems": 2,
+                                "maxItems": 3,
+                                "minItems": 3,
                                 "type": "array"
                             },
                             "tag": {
@@ -2819,6 +2857,29 @@
                     {
                         "properties": {
                             "contents": {
+                                "items": {
+                                    "format": "double",
+                                    "type": "number"
+                                },
+                                "type": "array"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "DefaultVecPadding"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "title": "DefaultVecPadding",
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contents": {
                                 "items": [
                                     {
                                         "multipleOf": 1.0e-2,
@@ -3384,6 +3445,29 @@
                             "contents"
                         ],
                         "title": "PrepaymentVec",
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contents": {
+                                "items": {
+                                    "format": "double",
+                                    "type": "number"
+                                },
+                                "type": "array"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "PrepaymentVecPadding"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "title": "PrepaymentVecPadding",
                         "type": "object"
                     },
                     {
@@ -9924,7 +10008,17 @@
                     {
                         "properties": {
                             "contents": {
-                                "type": "string"
+                                "items": [
+                                    {
+                                        "$ref": "#/components/schemas/BookDirection"
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "maxItems": 2,
+                                "minItems": 2,
+                                "type": "array"
                             },
                             "tag": {
                                 "enum": [
@@ -17601,6 +17695,50 @@
                     {
                         "properties": {
                             "contents": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "PayGroupPrin"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "title": "PayGroupPrin",
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contents": {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "PayGroupInt"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "title": "PayGroupInt",
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contents": {
                                 "items": [
                                     {
                                         "type": "string"
@@ -18418,6 +18556,62 @@
                 }
             }
         },
+        "/runByCombo": {
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json;charset=utf-8": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RunDealReq"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json;charset=utf-8": {
+                                "schema": {
+                                    "additionalProperties": {
+                                        "items": [
+                                            {
+                                                "$ref": "#/components/schemas/DealType"
+                                            },
+                                            {
+                                                "additionalProperties": {
+                                                    "$ref": "#/components/schemas/CashFlowFrame"
+                                                },
+                                                "type": "object"
+                                            },
+                                            {
+                                                "items": {
+                                                    "$ref": "#/components/schemas/ResultComponent"
+                                                },
+                                                "type": "array"
+                                            },
+                                            {
+                                                "additionalProperties": {
+                                                    "$ref": "#/components/schemas/PriceResult"
+                                                },
+                                                "type": "object"
+                                            }
+                                        ],
+                                        "maxItems": 4,
+                                        "minItems": 4,
+                                        "type": "array"
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "description": "Invalid `body`"
+                    }
+                }
+            }
+        },
         "/runDate": {
             "post": {
                 "requestBody": {
@@ -18490,85 +18684,6 @@
                                     ],
                                     "maxItems": 4,
                                     "minItems": 4,
-                                    "type": "array"
-                                }
-                            }
-                        },
-                        "description": ""
-                    },
-                    "400": {
-                        "description": "Invalid `body`"
-                    }
-                }
-            }
-        },
-        "/runDealByCombo": {
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json;charset=utf-8": {
-                            "schema": {
-                                "$ref": "#/components/schemas/RunDealReq"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json;charset=utf-8": {
-                                "schema": {
-                                    "items": {
-                                        "items": [
-                                            {
-                                                "items": [
-                                                    {
-                                                        "type": "string"
-                                                    },
-                                                    {
-                                                        "type": "string"
-                                                    },
-                                                    {
-                                                        "type": "string"
-                                                    }
-                                                ],
-                                                "maxItems": 3,
-                                                "minItems": 3,
-                                                "type": "array"
-                                            },
-                                            {
-                                                "items": [
-                                                    {
-                                                        "$ref": "#/components/schemas/DealType"
-                                                    },
-                                                    {
-                                                        "additionalProperties": {
-                                                            "$ref": "#/components/schemas/CashFlowFrame"
-                                                        },
-                                                        "type": "object"
-                                                    },
-                                                    {
-                                                        "items": {
-                                                            "$ref": "#/components/schemas/ResultComponent"
-                                                        },
-                                                        "type": "array"
-                                                    },
-                                                    {
-                                                        "additionalProperties": {
-                                                            "$ref": "#/components/schemas/PriceResult"
-                                                        },
-                                                        "type": "object"
-                                                    }
-                                                ],
-                                                "maxItems": 4,
-                                                "minItems": 4,
-                                                "type": "array"
-                                            }
-                                        ],
-                                        "maxItems": 2,
-                                        "minItems": 2,
-                                        "type": "array"
-                                    },
                                     "type": "array"
                                 }
                             }

--- a/swagger.json
+++ b/swagger.json
@@ -2956,6 +2956,35 @@
                         ],
                         "title": "DefaultAtEndByRate",
                         "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contents": {
+                                "items": [
+                                    {
+                                        "$ref": "#/components/schemas/Ts"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/AssetDefaultAssumption"
+                                    }
+                                ],
+                                "maxItems": 2,
+                                "minItems": 2,
+                                "type": "array"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "DefaultStressByTs"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "title": "DefaultStressByTs",
+                        "type": "object"
                     }
                 ]
             },
@@ -3502,6 +3531,35 @@
                             "contents"
                         ],
                         "title": "PrepayByAmt",
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contents": {
+                                "items": [
+                                    {
+                                        "$ref": "#/components/schemas/Ts"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/AssetPrepayAssumption"
+                                    }
+                                ],
+                                "maxItems": 2,
+                                "minItems": 2,
+                                "type": "array"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "PrepayStressByTs"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "title": "PrepayStressByTs",
                         "type": "object"
                     }
                 ]

--- a/test/MainTest.hs
+++ b/test/MainTest.hs
@@ -11,6 +11,7 @@ import qualified UT.BondTest as BT
 import qualified UT.LibTest as LT
 import qualified UT.ExpTest as ET
 import qualified UT.DealTest as DT
+import qualified UT.DealTest2 as DT2
 import qualified UT.QueryTest as QT
 import qualified UT.StmtTest as ST
 import qualified UT.UtilTest as UtilT
@@ -70,6 +71,7 @@ tests = testGroup "Tests" [AT.mortgageTests
                            ,DT.triggerTests
                            ,DT.dateTests
                            ,DT.liqProviderTest
+                           ,DT2.queryTests
                            ,UtilT.daycountTests1
                            ,UtilT.daycountTests2
                            ,UtilT.daycountTests3

--- a/test/UT/AssetTest.hs
+++ b/test/UT/AssetTest.hs
@@ -87,10 +87,12 @@ trs = CF.getTsCashFlowFrame tmcf_00
 
 mortgageCalcTests = testGroup "Mortgage Calc Test" 
   [
-    testCase "Calc Pmt" $
+    testCase "Calc Pmt 1" $
         assertEqual "PMT 01"
-           154.15
-           (AB.calcPmt 1200 0.12 24)
+           154.15 (AB.calcPmt 1200 0.12 24),
+    testCase "Calc Pmt 2" $
+        assertEqual "PMT 02"
+           100.0 (AB.calcPmt 1200 0.0 12)
   ]
 
 

--- a/test/UT/CashflowTest.hs
+++ b/test/UT/CashflowTest.hs
@@ -248,32 +248,45 @@ testMergeTsRowsFromTwoEntities =
 testMergePoolCf = 
   let 
     txn1 = CF.MortgageDelinqFlow (L.toDate "20230101") 100 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing
-    txn4 = CF.MortgageDelinqFlow (L.toDate "20230401") 90 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing
-    
     txn2 = CF.MortgageDelinqFlow (L.toDate "20230201") 100 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing
     txn3 = CF.MortgageDelinqFlow (L.toDate "20230301") 90 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing
+    txn4 = CF.MortgageDelinqFlow (L.toDate "20230401") 90 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing
     
     cf1 = CF.CashFlowFrame (110, L.toDate "20221201", Nothing) [txn1,txn4]
     cf2 = CF.CashFlowFrame (110, L.toDate "20230101", Nothing) [txn2,txn3]
+
+    cf3 = CF.CashFlowFrame (110, L.toDate "20221201", Nothing) [txn2,txn4]
+    cf4 = CF.CashFlowFrame (110, L.toDate "20221201", Nothing) [txn1,txn3]
+
+    cf5 = CF.CashFlowFrame (100, L.toDate "20221201", Nothing) [txn3,txn4]
+    cf6 = CF.CashFlowFrame (110, L.toDate "20230101", Nothing) [txn2]
+
   in 
     testGroup "Merge Cashflow Test from two entities"  -- merge cashflow into existing one without update previous balance
-    [ testCase "" $
-        assertEqual "Merge Cashflow Test 1"
+    [ testCase "Merge Cashflow Test 1" $
+        assertEqual ""
         (CF.CashFlowFrame (110 , L.toDate "20221201", Nothing)
                            [(CF.MortgageDelinqFlow (L.toDate "20230101") 100 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)
                            ,(CF.MortgageDelinqFlow (L.toDate "20230201") 200 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)
                            ,(CF.MortgageDelinqFlow (L.toDate "20230301") 190 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)
                            ,(CF.MortgageDelinqFlow (L.toDate "20230401") 180 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)]) 
         (CF.mergePoolCf2 cf1 cf2)
-      -- testCase "" $
-      --   assertEqual "Merge Cashflow with status"
-      --   (CF.CashFlowFrame dummySt 
-      --                      [(CF.MortgageDelinqFlow (L.toDate "20230101") 100 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)
-      --                      ,(CF.MortgageDelinqFlow (L.toDate "20230201") 200 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)
-      --                      ,(CF.MortgageDelinqFlow (L.toDate "20230301") 190 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)
-      --                      ,(CF.MortgageDelinqFlow (L.toDate "20230401") 180 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)]) 
-      --   (CF.mergePoolCf cf1 cf2),
-    ]
+      ,testCase "Merge Cashflow with same begin date 1" $
+        assertEqual ""
+        (CF.CashFlowFrame (220 , L.toDate "20221201", Nothing)
+                           [(CF.MortgageDelinqFlow (L.toDate "20230101") 210 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)
+                           ,(CF.MortgageDelinqFlow (L.toDate "20230201") 200 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)
+                           ,(CF.MortgageDelinqFlow (L.toDate "20230301") 190 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)
+                           ,(CF.MortgageDelinqFlow (L.toDate "20230401") 180 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)]) 
+        (CF.mergePoolCf2 cf3 cf4)
+      ,testCase "Merge Cashflow with diff begin date 2" $
+        assertEqual ""
+        (CF.CashFlowFrame (100 , L.toDate "20221201", Nothing)
+                           [(CF.MortgageDelinqFlow (L.toDate "20230201") 200 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)
+                           ,(CF.MortgageDelinqFlow (L.toDate "20230301") 190 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)
+                           ,(CF.MortgageDelinqFlow (L.toDate "20230401") 180 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)]) 
+        (CF.mergePoolCf2 cf5 cf6)
+      ]
 
 testHaircut = 
   let 

--- a/test/UT/CashflowTest.hs
+++ b/test/UT/CashflowTest.hs
@@ -264,7 +264,7 @@ testMergePoolCf =
                            ,(CF.MortgageDelinqFlow (L.toDate "20230201") 200 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)
                            ,(CF.MortgageDelinqFlow (L.toDate "20230301") 190 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)
                            ,(CF.MortgageDelinqFlow (L.toDate "20230401") 180 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)]) 
-        (CF.mergePoolCf cf1 cf2)
+        (CF.mergePoolCf2 cf1 cf2)
       -- testCase "" $
       --   assertEqual "Merge Cashflow with status"
       --   (CF.CashFlowFrame dummySt 

--- a/test/UT/CashflowTest.hs
+++ b/test/UT/CashflowTest.hs
@@ -252,17 +252,27 @@ testMergePoolCf =
     
     txn2 = CF.MortgageDelinqFlow (L.toDate "20230201") 100 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing
     txn3 = CF.MortgageDelinqFlow (L.toDate "20230301") 90 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing
-    cf1 = CF.CashFlowFrame dummySt [txn1,txn4]
-    cf2 = CF.CashFlowFrame dummySt [txn2,txn3]
+    
+    cf1 = CF.CashFlowFrame (110, L.toDate "20221201", Nothing) [txn1,txn4]
+    cf2 = CF.CashFlowFrame (110, L.toDate "20230101", Nothing) [txn2,txn3]
   in 
     testGroup "Merge Cashflow Test from two entities"  -- merge cashflow into existing one without update previous balance
     [ testCase "" $
         assertEqual "Merge Cashflow Test 1"
-        (CF.CashFlowFrame dummySt [(CF.MortgageDelinqFlow (L.toDate "20230101") 100 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)
+        (CF.CashFlowFrame (110 , L.toDate "20221201", Nothing)
+                           [(CF.MortgageDelinqFlow (L.toDate "20230101") 100 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)
                            ,(CF.MortgageDelinqFlow (L.toDate "20230201") 200 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)
                            ,(CF.MortgageDelinqFlow (L.toDate "20230301") 190 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)
                            ,(CF.MortgageDelinqFlow (L.toDate "20230401") 180 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)]) 
         (CF.mergePoolCf cf1 cf2)
+      -- testCase "" $
+      --   assertEqual "Merge Cashflow with status"
+      --   (CF.CashFlowFrame dummySt 
+      --                      [(CF.MortgageDelinqFlow (L.toDate "20230101") 100 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)
+      --                      ,(CF.MortgageDelinqFlow (L.toDate "20230201") 200 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)
+      --                      ,(CF.MortgageDelinqFlow (L.toDate "20230301") 190 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)
+      --                      ,(CF.MortgageDelinqFlow (L.toDate "20230401") 180 10 10 0 0 0 0 0 0.0 Nothing Nothing Nothing)]) 
+      --   (CF.mergePoolCf cf1 cf2),
     ]
 
 testHaircut = 

--- a/test/UT/DealTest.hs
+++ b/test/UT/DealTest.hs
@@ -130,7 +130,7 @@ td2 = D.TestDeal {
                                  ]
                  ,P.futureCf=Nothing
                  ,P.asOfDate = T.fromGregorian 2022 1 1
-                 ,P.issuanceStat = Nothing}
+                 ,P.issuanceStat = Just $ Map.fromList [(RuntimeCurrentPoolBalance, 70)]}
    ,D.waterfall = Map.fromList [(W.DistributionDay Amortizing, [
                                   (W.PayFee Nothing "General" ["Service-Fee"] Nothing)
                                  ,(W.PayInt Nothing "General" ["A"] Nothing)

--- a/test/UT/DealTest2.hs
+++ b/test/UT/DealTest2.hs
@@ -1,4 +1,4 @@
-module UT.DealTest(td2,queryTests,triggerTests,dateTests,liqProviderTest)
+module UT.DealTest2 (td,queryTests)
 
 where
 
@@ -32,9 +32,8 @@ import Types (PoolId(PoolConsol))
 
 dummySt = (0,toDate "19000101",Nothing)
 
-
-td2 = D.TestDeal {
-  D.name = "test deal1"
+td = D.TestDeal {
+  D.name = "test deal"
   ,D.status = Amortizing
   ,D.rateSwap = Nothing
   ,D.currencySwap = Nothing
@@ -44,12 +43,8 @@ td2 = D.TestDeal {
                 ,(CutoffDate,((T.fromGregorian 2022 1 1),MonthFirst,(toDate "20300101")))
                 ,(FirstPayDate,((T.fromGregorian 2022 2 25),DayOfMonth 25,(toDate "20300101")))
                ])
-  ,D.accounts = (Map.fromList
-  [("General", (A.Account { A.accName="General" ,A.accBalance=1000.0 ,A.accType=Nothing, A.accInterest=Nothing ,A.accStmt=Nothing
-  })),
-   ("Reserve", (A.Account { A.accName="Reserve" ,A.accBalance=0.0 ,A.accType=Just (A.FixReserve 500), A.accInterest=Nothing ,A.accStmt=Nothing
-  }))
-  ])
+  ,D.accounts = Map.fromList
+                [("General", A.Account { A.accName="General" ,A.accBalance=1000.0 ,A.accType=Nothing, A.accInterest=Nothing ,A.accStmt=Nothing })]
   ,D.fees = (Map.fromList [("Service-Fee"
                          ,F.Fee{F.feeName="service-fee"
                                 ,F.feeType = F.FixFee 10
@@ -136,128 +131,105 @@ td2 = D.TestDeal {
                                  ,(W.PayInt Nothing "General" ["A"] Nothing)
                                  ,(W.PayPrin Nothing "General" ["A"] Nothing)
    ])]
- ,D.collects = [W.Collect Nothing W.CollectedInterest "General"
-             ,W.Collect Nothing W.CollectedPrincipal "General"]
+ ,D.collects = [W.Collect Nothing W.CollectedCash "General"]
  ,D.custom = Nothing
  ,D.call = Nothing
- ,D.liqProvider = Just $ Map.fromList $
-                    [("Liq1",CE.LiqFacility 
-                                "" 
-                                (CE.FixSupport 100)
-                                50
-                                (Just 100)
-                                Nothing
-                                Nothing
-                                Nothing
-                                Nothing
-                                Nothing 
-                                0
-                                0
-                                (toDate "20220201")
-                                Nothing
-                                (Just (S.Statement [SupportTxn (toDate "20220215") (Just 110) 10 40 0 0 S.Empty 
-                                                    ,SupportTxn (toDate "20220315") (Just 100) 10 50 0 0 S.Empty])))]
- ,D.triggers = Just $
-                Map.fromList $
-                  [(BeginDistributionWF,
-                    Map.fromList [ ("revolving trigger",Trg.Trigger{Trg.trgCondition = IfDate G (toDate "20220501")
-                                                                    ,Trg.trgEffects = Trg.DealStatusTo Revolving
-                                                                    ,Trg.trgStatus = False 
-                                                                    ,Trg.trgCurable = False })]
-                                                                    )]
+ ,D.liqProvider = Nothing
+ ,D.triggers = Nothing
  ,D.overrides = Nothing
  ,D.ledgers = Nothing
 }
 
-queryTests =  testGroup "deal stat query Tests"
+bondGroups = Map.fromList [("A"
+                             ,L.BondGroup (Map.fromList 
+                               [
+                                ("A-1",L.Bond{
+                                        L.bndName="A-1"
+                                        ,L.bndType=L.Sequential
+                                        ,L.bndOriginInfo= L.OriginalInfo{
+                                                            L.originBalance=3000
+                                                            ,L.originDate= (T.fromGregorian 2022 1 1)
+                                                            ,L.originRate= 0.08
+                                                            ,L.maturityDate = Nothing}
+                                        ,L.bndInterestInfo= L.Fix 0.08 DC_ACT_365F
+                                        ,L.bndBalance=1500
+                                        ,L.bndRate=0.08
+                                        ,L.bndDuePrin=0.0
+                                        ,L.bndDueInt=0.0
+                                        ,L.bndDueIntOverInt=0.0
+                                        ,L.bndDueIntDate=Nothing
+                                        ,L.bndLastIntPay = Just (T.fromGregorian 2022 1 1)
+                                        ,L.bndLastPrinPay = Just (T.fromGregorian 2022 1 1)
+                                        ,L.bndStmt=Nothing}),
+                                ("A-2",L.Bond{
+                                        L.bndName="A-2"
+                                        ,L.bndType=L.Sequential
+                                        ,L.bndOriginInfo= L.OriginalInfo{
+                                                            L.originBalance=2000
+                                                            ,L.originDate= (T.fromGregorian 2022 1 1)
+                                                            ,L.originRate= 0.08
+                                                            ,L.maturityDate = Nothing}
+                                        ,L.bndInterestInfo= L.Fix 0.08 DC_ACT_365F
+                                        ,L.bndBalance=1000
+                                        ,L.bndRate=0.08
+                                        ,L.bndDuePrin=0.0
+                                        ,L.bndDueInt=0.0
+                                        ,L.bndDueIntOverInt=0.0
+                                        ,L.bndDueIntDate=Nothing
+                                        ,L.bndLastIntPay = Just (T.fromGregorian 2022 1 1)
+                                        ,L.bndLastPrinPay = Just (T.fromGregorian 2022 1 1)
+                                        ,L.bndStmt=Nothing})
+                                 ]            
+                                ))
+                             ,("B"
+                               ,L.Bond{
+                                L.bndName="B"
+                               ,L.bndType=L.Equity
+                               ,L.bndOriginInfo= L.OriginalInfo{
+                                                  L.originBalance=3000
+                                                  ,L.originDate= (T.fromGregorian 2022 1 1)
+                                                  ,L.originRate= 0.08
+                                                  ,L.maturityDate = Nothing}
+                               ,L.bndInterestInfo= L.Fix 0.08 DC_ACT_365F
+                               ,L.bndBalance=500
+                               ,L.bndRate=0.08
+                               ,L.bndDuePrin=0.0
+                               ,L.bndDueInt=0.0
+                               ,L.bndDueIntDate=Nothing
+                               ,L.bndLastIntPay = Just (T.fromGregorian 2022 1 1)
+                               ,L.bndLastPrinPay = Just (T.fromGregorian 2022 1 1)
+                               ,L.bndStmt=Nothing})
+                            ]
+
+tdBondGroup = td { D.bonds = bondGroups,
+                   D.waterfall = Map.fromList [(W.DistributionDay Amortizing, [
+                                  W.PayFee Nothing "General" ["Service-Fee"] Nothing
+                                 ,W.AccrueAndPayInt Nothing "General" ["A"] Nothing
+                                 ,W.PayPrinGroup Nothing "General" "A" W.ByProRataCurBal Nothing
+                                 ,W.PayPrin Nothing "General" ["B"] Nothing
+                ])]
+   }
+
+queryTests =  testGroup "Deal Group Test"
   [
     let
-     currentDefBal = queryDeal td2 CurrentPoolDefaultedBalance
+     currBndGrpBal = queryDeal tdBondGroup (CurrentBondBalanceOf ["A"])
     in
-     testCase "query current assets in defaulted status" $
-     assertEqual "should be 200" 200 currentDefBal
-  ]
-
-triggerTests = testGroup "Trigger Tests"
-  [ let 
-      setup = 0 
-      poolflows = CF.CashFlowFrame dummySt $
-                     [CF.MortgageDelinqFlow (toDate "20220201") 800 100 20 0 0 0 0 0 0.08 Nothing Nothing Nothing 
-                     ,CF.MortgageDelinqFlow (toDate "20220301") 700 100 20 0 0 0 0 0 0.08 Nothing Nothing Nothing
-                     ,CF.MortgageDelinqFlow (toDate "20220401") 600 100 20 0 0 0 0 0 0.08 Nothing Nothing Nothing 
-                     ,CF.MortgageDelinqFlow (toDate "20220501") 500 100 20 0 0 0 0 0 0.08 Nothing Nothing Nothing
-                     ,CF.MortgageDelinqFlow (toDate "20220601") 400 100 20 0 0 0 0 0 0.08 Nothing Nothing Nothing
-                     ,CF.MortgageDelinqFlow (toDate "20220701") 300 100 20 0 0 0 0 0 0.08 Nothing Nothing Nothing
-                     ]
-      poolflowM = Map.fromList [(PoolConsol, poolflows)]
-      ads = [PoolCollection (toDate "20220201") "" 
-             ,RunWaterfall  (toDate "20220225") ""
-             ,PoolCollection (toDate "20220301")""
-             ,RunWaterfall  (toDate "20220325") ""
-             ,PoolCollection (toDate "20220401")""
-             ,RunWaterfall  (toDate "20220425") ""
-             ,PoolCollection (toDate "20220501")""
-             ,RunWaterfall  (toDate "20220525") ""
-             ,PoolCollection (toDate "20220601")""
-             ,RunWaterfall  (toDate "20220625") ""
-             ,PoolCollection (toDate "20220701")""
-             ,RunWaterfall  (toDate "20220725") ""  ]
-      (fdeal,_) = run td2 poolflowM (Just ads) Nothing Nothing Nothing []
+     testCase "group bond balance" $
+     assertEqual "should be 2500" 2500 currBndGrpBal
+    ,let 
+        bndsFound = D.viewDealAllBonds tdBondGroup
+     in 
+        testCase "view viewDealAllBonds " $
+        assertEqual "should be 3" 3 (length bndsFound)
+    ,let 
+        totalBndBal = queryDeal tdBondGroup CurrentBondBalance 
     in 
-      testCase "deal becomes revolving" $
-      assertEqual "revoving" 
-        Revolving 
-        (D.status fdeal)
+        testCase "total bond balance" $
+        assertEqual "should be 3000" 3000 totalBndBal
+    ,let
+        originBndbal = queryDeal tdBondGroup (OriginalBondBalanceOf ["A"])
+    in
+        testCase "original bond balance" $
+        assertEqual "should be 5000" 5000 originBndbal
   ]
-
-dateTests = 
-  let 
-   a = PreClosingDates
-        (toDate "20220601") 
-        (toDate "20220610") 
-        Nothing
-        (toDate "20220901") 
-        (toDate "20220630",MonthEnd)
-        (toDate "20220715",DayOfMonth 10)
-  in 
-   testGroup "Deal Tests" 
-   [ testCase "Dates pattern" $
-     assertEqual  ""
-    ((toDate "20220601"), (toDate "20220610"),(toDate "20220715")
-     ,[PoolCollection (toDate "20220630") "",PoolCollection (toDate "20220731") "",PoolCollection (toDate "20220831") ""]
-     ,[RunWaterfall (toDate "20220715") "",RunWaterfall (toDate "20220810") ""]
-     ,(toDate "20220901") )
-     (populateDealDates a Amortizing)
-   ]
-  
-liqProviderTest = 
-  let 
-    liq1 = CE.LiqFacility "" 
-                       (CE.FixSupport 100)
-
-                       90
-                       (Just 100)
-
-                       Nothing -- rate type
-                       Nothing -- premium rate type
-                       
-                       Nothing -- rate
-                       Nothing -- premium reate
-
-                       (Just (toDate "20220201"))
-                       0
-                       0
-                       
-                       (toDate "20220301")
-                       Nothing
-                       (Just (S.Statement 
-                               [SupportTxn (toDate "20220215") (Just 110) 40 40 0 0 S.Empty
-                               ,SupportTxn (toDate "20220315") (Just 100) 50 90 0 0 S.Empty
-                               ]))
-  in 
-    testGroup "Liq provider test" 
-      [testCase "Liq Provider Int test" $
-          assertEqual ""
-           (Just 100)
-           (CE.liqCredit $ CE.accrueLiqProvider (toDate "20221101") liq1)
-      ]

--- a/test/UT/UtilTest.hs
+++ b/test/UT/UtilTest.hs
@@ -236,13 +236,21 @@ tsTest =
     d1 = T.fromGregorian 2007 12 28
     d2 = T.fromGregorian 2008 2 28
     dpairs = [(toDate "20061201",100)
-                  ,(toDate "20070201",80)  
-                  ,(toDate "20080201",60)]
+              ,(toDate "20070201",80)  
+              ,(toDate "20080201",60)]
     ed =  (toDate "20090101")
     testTs = mkTs [(toDate "20061201",100)
                   ,(toDate "20070201",80)  
                   ,(toDate "20080201",60)]
     tps = [TsPoint _d _v | (_d,_v) <- dpairs ]
+
+    rateCurve = FloatCurve [TsPoint (toDate "20061201") 0.03
+                           ,TsPoint (toDate "20070201") 0.05
+                           ,TsPoint (toDate "20080201") 0.07]
+
+    factorCurve = FloatCurve [TsPoint (toDate "20061201") 1.0
+                             ,TsPoint (toDate "20070201") 0.8
+                             ,TsPoint (toDate "20080201") 0.6]
   in
     testGroup "Test Trigger Factor Curve"
   [
@@ -276,12 +284,17 @@ tsTest =
           Exc
           (toDate "20081221") 
     ,testCase "FactorCurveClosed" $                         
-      assertEqual "After end date"
+      assertEqual "After end date" 
         1.0 $
         getValByDate 
           (FactorCurveClosed tps ed)
           Exc
           (toDate "20090601")
+    ,testCase "Multiply Ts" $
+      assertEqual " multiplyTs 1 "
+        (mkTs [(toDate "20061201", 0.03) ,(toDate "20070201", 0.04),(toDate "20080201", 0.042)]) 
+        (multiplyTs Inc rateCurve factorCurve)
+
   ]
 
 ts2Test = 


### PR DESCRIPTION
* BUG: fix pool balance when there are multiple assets in revolving pool
* FIX: remove duplication of waterfall execution in a call execution
* NEW: add new sensitivity endpoint which include 3 maps of input (deal, pool perf, deal assump)
* NEW: writeOff sequentially to list of bonds, 
* NEW: clear ledger in the ``Limit``
* BREAK: select a pool to sell/liquidate
* ENHANCE: patch cashflow status(begBal,begDate,AccInt) on asset cashflow 
* NEW: prepayment/default extra stress curve
* NEW: waterfall action :transfer multiple accounts to single one