### PR TITLE
0.41.x

### DIFF
--- a/.github/workflows/docker-image-dev-by-tag.yml
+++ b/.github/workflows/docker-image-dev-by-tag.yml
@@ -27,11 +27,9 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: yellowbean/hastructure
-          tags: |
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
           
       - name: 'Cleanup build folder'
         run: |

--- a/.github/workflows/docker-image-dev-by-tag.yml
+++ b/.github/workflows/docker-image-dev-by-tag.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           images: yellowbean/hastructure
           tags: |
-            type=semver,pattern={{raw}}
+            type=match,pattern=(a\d+.\d+.\d+),group=1
           flavor: |
             latest=false 
           

--- a/.github/workflows/docker-image-dev-by-tag.yml
+++ b/.github/workflows/docker-image-dev-by-tag.yml
@@ -30,6 +30,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: yellowbean/hastructure
+          tags: |
+            type=match,pattern=(a\d+.\d+.\d+)
           
       - name: 'Cleanup build folder'
         run: |

--- a/.github/workflows/docker-image-dev-by-tag.yml
+++ b/.github/workflows/docker-image-dev-by-tag.yml
@@ -31,7 +31,9 @@ jobs:
         with:
           images: yellowbean/hastructure
           tags: |
-            type=match,pattern=(a\d+.\d+.\d+)
+            type=semver,pattern={{raw}}
+          flavor: |
+            latest=false 
           
       - name: 'Cleanup build folder'
         run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@v5
         with:
           images: yellowbean/hastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,23 @@
 <!-- towncrier release notes start -->
 
 
+## 0.40.6
+### 2024-12-06 
+* NEW: new formula `ledgerBalanceBy`, which return either `Credit` or `Debit` balance of a ledger
+* FIX: step-up coupon bond which has a floater index will increase forever
+* ENHANCE: refactor on `PDL` book type.
+* ENHANCE: 
+
+
 ## 0.40.1
 ### 2024-11-05
 * NEW: break changes on API ,now the engine is able to throw out error message instead of just hanging.
 
 
 ## 0.31.0
-
 ### 2024-11-05
 * NEW: new Call options assumption ,which specifies `dates` to be tested
-* NEW: 
-* ENHANCE: transform financial report to a Tree from a Table
+* ENHANCE: transform financial report to a `Tree` from a `Table`
 
 ## 0.30.5
 ### 2024-11-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,17 @@
 <!-- towncrier release notes start -->
 
 
+## 0.40.9
+### 2024-12-11
+* ENHANCE:  Ensure <limit> always return positive ,otherwise engine will throw error
+* NEW: add new action  `changeStatus` in waterfall, with optional `Pre` as condition to trigger the status change
+
+
 ## 0.40.6
 ### 2024-12-06 
 * NEW: new formula `ledgerBalanceBy`, which return either `Credit` or `Debit` balance of a ledger
 * FIX: step-up coupon bond which has a floater index will increase forever
 * ENHANCE: refactor on `PDL` book type.
-* ENHANCE: 
 
 
 ## 0.40.1

--- a/Hastructure.cabal
+++ b/Hastructure.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 

--- a/Hastructure.cabal
+++ b/Hastructure.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           Hastructure
-version:        0.26.5
+version: 0.40.5
 description:    Please see the README on GitHub at <https://github.com/yellowbean/Hastructure#readme>
 category:       StructuredFinance;Securitisation;Cashflow
 homepage:       https://github.com/yellowbean/Hastructure#readme

--- a/Hastructure.cabal
+++ b/Hastructure.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           Hastructure
-version: 0.40.6
+version: 0.40.7
 description:    Please see the README on GitHub at <https://github.com/yellowbean/Hastructure#readme>
 category:       StructuredFinance;Securitisation;Cashflow
 homepage:       https://github.com/yellowbean/Hastructure#readme

--- a/Hastructure.cabal
+++ b/Hastructure.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           Hastructure
-version:        0.26.5
+version: 0.40.6
 description:    Please see the README on GitHub at <https://github.com/yellowbean/Hastructure#readme>
 category:       StructuredFinance;Securitisation;Cashflow
 homepage:       https://github.com/yellowbean/Hastructure#readme

--- a/Hastructure.cabal
+++ b/Hastructure.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           Hastructure
-version:	 0.40.9
+version:        0.40.9
 description:    Please see the README on GitHub at <https://github.com/yellowbean/Hastructure#readme>
 category:       StructuredFinance;Securitisation;Cashflow
 homepage:       https://github.com/yellowbean/Hastructure#readme

--- a/Hastructure.cabal
+++ b/Hastructure.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           Hastructure
-version:        0.40.9
+version:	 0.40.10
 description:    Please see the README on GitHub at <https://github.com/yellowbean/Hastructure#readme>
 category:       StructuredFinance;Securitisation;Cashflow
 homepage:       https://github.com/yellowbean/Hastructure#readme

--- a/Hastructure.cabal
+++ b/Hastructure.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           Hastructure
-version: 0.40.7
+version: 0.40.8
 description:    Please see the README on GitHub at <https://github.com/yellowbean/Hastructure#readme>
 category:       StructuredFinance;Securitisation;Cashflow
 homepage:       https://github.com/yellowbean/Hastructure#readme

--- a/Hastructure.cabal
+++ b/Hastructure.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           Hastructure
-version:	 0.40.10
+version:	 0.40.11
 description:    Please see the README on GitHub at <https://github.com/yellowbean/Hastructure#readme>
 category:       StructuredFinance;Securitisation;Cashflow
 homepage:       https://github.com/yellowbean/Hastructure#readme

--- a/Hastructure.cabal
+++ b/Hastructure.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           Hastructure
-version:        0.40.4
+version:	 0.40.9
 description:    Please see the README on GitHub at <https://github.com/yellowbean/Hastructure#readme>
 category:       StructuredFinance;Securitisation;Cashflow
 homepage:       https://github.com/yellowbean/Hastructure#readme

--- a/Hastructure.cabal
+++ b/Hastructure.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           Hastructure
-version: 0.40.5
+version:        0.26.5
 description:    Please see the README on GitHub at <https://github.com/yellowbean/Hastructure#readme>
 category:       StructuredFinance;Securitisation;Cashflow
 homepage:       https://github.com/yellowbean/Hastructure#readme

--- a/Hastructure.cabal
+++ b/Hastructure.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           Hastructure
-version: 0.40.8
+version:        0.40.4
 description:    Please see the README on GitHub at <https://github.com/yellowbean/Hastructure#readme>
 category:       StructuredFinance;Securitisation;Cashflow
 homepage:       https://github.com/yellowbean/Hastructure#readme
@@ -18,7 +18,7 @@ license-file:   LICENSE
 build-type:     Simple
 extra-source-files:
     README.md
-    ChangeLog.md
+    CHANGELOG.md
 
 source-repository head
   type: git

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -115,7 +115,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.40.3"
+version1 = Version "0.40.4"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -115,7 +115,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.40.6"
+version1 = Version "0.40.7"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -115,7 +115,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.40.1"
+version1 = Version "0.40.3"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -115,7 +115,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.40.9"
+version1 = Version "0.40.10"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -115,7 +115,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.40.8"
+version1 = Version "0.40.5"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -92,11 +92,11 @@ import qualified DateUtil as DU
 
 import Data.Scientific (fromRationalRepetend,formatScientific, Scientific,FPFormat(Fixed))
 import Control.Lens
-import Debug.Trace
 import qualified Types as W
 import Cashflow (patchCumulative)
 
 
+import Debug.Trace
 debug = flip Debug.Trace.trace
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -115,7 +115,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.40.4"
+version1 = Version "0.40.5"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -115,7 +115,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.40.10"
+version1 = Version "0.40.11"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -304,7 +304,7 @@ wrapRun (PDeal d) mAssump mNonPerfAssump
       (_d,_pflow,_rs,_p) <- D.runDeal d D.DealPoolFlowPricing mAssump mNonPerfAssump
       return (PDeal _d,_pflow,_rs,_p)
 
-wrapRun x _ _ = error $ "RunDeal Failed ,due to unsupport deal type "++ show x
+wrapRun x _ _ = Left $ "RunDeal Failed ,due to unsupport deal type "++ show x
 
 
 data PoolTypeWrap = LPool (DB.PoolType AB.Loan)
@@ -337,7 +337,7 @@ wrapRunPoolType (FPool pt) assump mRates = D.runPoolType pt assump $ Just (AP.No
 wrapRunPoolType (VPool pt) assump mRates = D.runPoolType pt assump $ Just (AP.NonPerfAssumption{AP.interest = mRates})
 wrapRunPoolType (PPool pt) assump mRates = D.runPoolType pt assump $ Just (AP.NonPerfAssumption{AP.interest = mRates})
 wrapRunPoolType (UPool pt) assump mRates = D.runPoolType pt assump $ Just (AP.NonPerfAssumption{AP.interest = mRates})
-wrapRunPoolType x _ _ = error $ "RunPool Failed ,due to unsupport pool type "++ show x
+wrapRunPoolType x _ _ = Left $ "RunPool Failed ,due to unsupport pool type "++ show x
 
 
 data RunAssetReq = RunAssetReq Date [AB.AssetUnion] (Maybe AP.ApplyAssumptionType) (Maybe [RateAssumption]) (Maybe PricingMethod)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -115,7 +115,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.40.5"
+version1 = Version "0.40.6"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -115,7 +115,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.40.5"
+version1 = Version "0.40.9"
 
 
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -115,7 +115,7 @@ $(deriveJSON defaultOptions ''Version)
 instance ToSchema Version
 
 version1 :: Version 
-version1 = Version "0.40.7"
+version1 = Version "0.40.8"
 
 
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                Hastructure
-version:	 0.40.9
+version:	 0.40.10
 github:              "yellowbean/Hastructure"
 license:             BSD3
 author:              "Xiaoyu"

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                Hastructure
-version:	0.26.5
+version:	 0.40.4
 github:              "yellowbean/Hastructure"
 license:             BSD3
 author:              "Xiaoyu"
@@ -8,7 +8,7 @@ copyright:           "2024 Xiaoyu, Zhang"
 
 extra-source-files:
 - README.md
-- ChangeLog.md
+- CHANGELOG.md
 
 # Metadata used when publishing your package
 # synopsis:            Short description of your package

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                Hastructure
-version:	 0.40.10
+version:	 0.40.11
 github:              "yellowbean/Hastructure"
 license:             BSD3
 author:              "Xiaoyu"

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                Hastructure
-version:	 0.40.4
+version:	 0.40.9
 github:              "yellowbean/Hastructure"
 license:             BSD3
 author:              "Xiaoyu"

--- a/src/Accounts.hs
+++ b/src/Accounts.hs
@@ -98,11 +98,10 @@ depositInt ed a@(Account bal _ (Just intType) _ stmt)
             newStmt = appendStmt stmt newTxn
 
 -- | move cash from account A to account B
-transfer :: Account -> Amount -> Date -> Account -> (Account, Account)
-transfer sourceAcc@(Account sBal san _ _ sStmt)
-         amount
+transfer :: (Account,Account) -> Date -> Amount -> (Account, Account)
+transfer (sourceAcc@(Account sBal san _ _ sStmt), targetAcc@(Account tBal tan _ _ tStmt))
          d
-         targetAcc@(Account tBal tan _ _ tStmt)
+         amount
   = (sourceAcc {accBalance = newSBal, accStmt = sourceNewStmt}
     ,targetAcc {accBalance = newTBal, accStmt = targetNewStmt})
   where
@@ -121,7 +120,9 @@ deposit amount d source acc@(Account bal _ _ _ maybeStmt)  =
 
 -- | draw cash from account with a comment
 draw :: Amount -> Date -> TxnComment -> Account -> Account
-draw amount = deposit (- amount) 
+draw amount d txn acc@Account{ accBalance = bal ,accName = an} 
+  | bal >= amount = deposit (- amount) d txn acc  
+  | otherwise = error  $ "Date:"++ show d ++" Failed to draw "++ show amount ++" from account" ++ an
 
 -- | draw cash from account with a comment,return shortfall and acccount 
 tryDraw :: Amount -> Date -> TxnComment -> Account -> ((Amount,Amount),Account)

--- a/src/AssetClass/AssetCashflow.hs
+++ b/src/AssetClass/AssetCashflow.hs
@@ -84,7 +84,7 @@ applyHaircut (Just A.ExtraStress{A.poolHairCut = Just haircuts}) (CF.CashFlowFra
 patchPrepayPenaltyFlow :: (Int,Maybe PrepayPenaltyType) -> CF.CashFlowFrame -> CF.CashFlowFrame
 patchPrepayPenaltyFlow (ot,mPpyPen) mflow@(CF.CashFlowFrame st trs) 
   = let 
-      (startDate,endDate) = CF.getDateRangeCashFlowFrame mflow
+      --(startDate,endDate) = CF.getDateRangeCashFlowFrame mflow
       prepaymentFlow = CF.mflowPrepayment <$> trs
       flowSize = CF.sizeCashFlowFrame mflow
     in 

--- a/src/AssetClass/Installment.hs
+++ b/src/AssetClass/Installment.hs
@@ -175,6 +175,8 @@ instance Asset Installment where
   projCashflow inst@(Installment _ cb rt (Defaulted Nothing)) asOfDay assumps _
     = Right $ (CF.CashFlowFrame (cb, asOfDay, Nothing) $ [CF.LoanFlow asOfDay cb 0 0 0 0 0 0 (getOriginRate inst) Nothing],Map.empty)
         
+  projCashflow a b c d = Left $ "Failed to match when proj mortgage with assumption >>" ++ show a ++ show b ++ show c ++ show d
+  
   splitWith (Installment (LoanOriginalInfo ob or ot p sd _type _obligor) cb rt st) rs
     = [ Installment (LoanOriginalInfo (mulBR ob ratio) or ot p sd _type _obligor) (mulBR cb ratio) rt st | ratio <- rs ]
 

--- a/src/AssetClass/Lease.hs
+++ b/src/AssetClass/Lease.hs
@@ -239,6 +239,8 @@ instance Asset Lease where
         begBal = CF.buildBegBal allTxns
         
 
+    projCashflow a b c d = Left $ "Failed to match when proj mortgage with assumption >>" ++ show a ++ show b ++ show c ++ show d
+    
     getCurrentBal l = case l of 
                         StepUpLease _ _ bal _ _ -> bal
                         RegularLease _ bal _ _-> bal

--- a/src/AssetClass/Lease.hs
+++ b/src/AssetClass/Lease.hs
@@ -239,7 +239,7 @@ instance Asset Lease where
         begBal = CF.buildBegBal allTxns
         
 
-    projCashflow a b c d = Left $ "Failed to match when proj mortgage with assumption >>" ++ show a ++ show b ++ show c ++ show d
+    projCashflow a b c d = Left $ "Failed to match when proj lease with assumption >>" ++ show a ++ show b ++ show c ++ show d
     
     getCurrentBal l = case l of 
                         StepUpLease _ _ bal _ _ -> bal

--- a/src/AssetClass/Loan.hs
+++ b/src/AssetClass/Loan.hs
@@ -166,7 +166,7 @@ instance Asset Loan where
   projCashflow m@(PersonalLoan (LoanOriginalInfo ob or ot p sd prinPayType _) cb cr rt (Defaulted Nothing)) asOfDay assumps _
     = Right $ (CF.CashFlowFrame (cb,asOfDay,Nothing) [CF.LoanFlow asOfDay 0 0 0 0 0 0 0 cr Nothing],Map.empty)
   
-  projCashflow a b c d = Left $ "failed to match projCashflow"++show a++show b++show c++show d
+  projCashflow a b c d = Left $ "failed to match projCashflow for Loan "++show a++show b++show c++show d
   
   splitWith l@(PersonalLoan (LoanOriginalInfo ob or ot p sd prinPayType obr) cb cr rt st) rs
     = [ PersonalLoan (LoanOriginalInfo (mulBR ob ratio) or ot p sd prinPayType obr) (mulBR cb ratio) cr rt st | ratio <- rs ]

--- a/src/AssetClass/ProjectedCashFlow.hs
+++ b/src/AssetClass/ProjectedCashFlow.hs
@@ -194,6 +194,8 @@ instance Ast.Asset ProjectedCashflow where
           Right $ (foldl CF.combine fixedCashFlow floatedCashFlow, Map.empty)
           --(fixedCashFlow, Map.empty)
 
+    projCashflow a b c d = Left $ "Failed to match when proj projected flow with assumption >>" ++ show a ++ show b ++ show c ++ show d
+    
     getBorrowerNum f = 0
 
     splitWith f rs = [f]

--- a/src/AssetClass/Receivable.hs
+++ b/src/AssetClass/Receivable.hs
@@ -163,3 +163,5 @@ instance Asset Receivable where
       
       txns = [initTxn, CF.ReceivableFlow payDate 0 0 principal feePaid defaultAmt 0 realizedLoss Nothing]
       (futureTxns,historyM) = CF.cutoffTrs asOfDay $ txns++(buildRecoveryCfs payDate defaultAmt amr) -- `debug` ("recovery flow"++ show (buildRecoveryCfs payDate defaultAmt amr))
+    
+  projCashflow a b c d = Left $ "Failed to match when proj receivable with assumption >>" ++ show a ++ show b ++ show c ++ show d

--- a/src/Cashflow.hs
+++ b/src/Cashflow.hs
@@ -13,7 +13,7 @@ module Cashflow (CashFlowFrame(..),Principals,Interests,Amount
                 ,mflowBorrowerNum,mflowPrepaymentPenalty
                 ,emptyTsRow,mflowAmortAmount
                 ,tsTotalCash, setPrepaymentPenalty, setPrepaymentPenaltyFlow
-                ,getDate,getTxnLatestAsOf
+                ,getDate,getTxnLatestAsOf,totalPrincipal
                 ,mflowWeightAverageBalance
                 ,addFlowBalance,totalLoss,totalDefault,totalRecovery,firstDate
                 ,shiftCfToStartDate,cfInsertHead,buildBegTsRow,insertBegTsRow
@@ -824,6 +824,9 @@ totalDefault (CashFlowFrame _ rs) = sum $ mflowDefault <$> rs
 
 totalRecovery :: CashFlowFrame -> Balance
 totalRecovery (CashFlowFrame _ rs) = sum $ mflowRecovery <$> rs
+
+totalPrincipal :: CashFlowFrame -> Balance
+totalPrincipal (CashFlowFrame _ rs) = sum $ mflowPrincipal <$> rs
 
 -- ^ merge two cashflow frame but no patching beg balance
 mergePoolCf :: CashFlowFrame -> CashFlowFrame -> CashFlowFrame

--- a/src/Cashflow.hs
+++ b/src/Cashflow.hs
@@ -3,11 +3,11 @@
 
 module Cashflow (CashFlowFrame(..),Principals,Interests,Amount
                 ,combine,mergePoolCf,sumTsCF,tsSetDate,tsSetLoss,tsSetRecovery
-                ,sizeCashFlowFrame,aggTsByDates, getTsCashFlowFrame
+                ,sizeCashFlowFrame,aggTsByDates
                 ,mflowInterest,mflowPrincipal,mflowRecovery,mflowPrepayment
                 ,mflowRental,mflowRate,sumPoolFlow,splitTrs,aggregateTsByDate
                 ,mflowDefault,mflowLoss,mflowDate
-                ,getSingleTsCashFlowFrame,getDatesCashFlowFrame,getDateRangeCashFlowFrame
+                ,getSingleTsCashFlowFrame,getDatesCashFlowFrame
                 ,lookupSource,lookupSourceM,combineTss
                 ,mflowBalance,mflowBegBalance,tsDefaultBal
                 ,mflowBorrowerNum,mflowPrepaymentPenalty
@@ -221,14 +221,12 @@ instance Show CashFlowFrame where
 sizeCashFlowFrame :: CashFlowFrame -> Int
 sizeCashFlowFrame (CashFlowFrame _ ts) = length ts
 
-getTsCashFlowFrame :: CashFlowFrame -> [TsRow]
-getTsCashFlowFrame (CashFlowFrame _ ts) = ts
-
 getDatesCashFlowFrame :: CashFlowFrame -> [Date]
 getDatesCashFlowFrame (CashFlowFrame _ ts) = getDates ts
 
-getDateRangeCashFlowFrame :: CashFlowFrame -> (Date,Date)
-getDateRangeCashFlowFrame (CashFlowFrame _ trs) = (getDate (head trs), getDate (last trs))
+-- getDateRangeCashFlowFrame :: CashFlowFrame -> (Date,Date) --TODO what if it is empty ? 
+-- getDateRangeCashFlowFrame (CashFlowFrame _ [tr]) = (getDate tr, getDate tr)
+-- getDateRangeCashFlowFrame (CashFlowFrame _ trs) = (getDate (head trs), getDate (last trs))
 
 getBegBalCashFlowFrame :: CashFlowFrame -> Balance
 getBegBalCashFlowFrame (CashFlowFrame _ []) = 0
@@ -1188,6 +1186,8 @@ txnCumulativeStats = lens getter setter
     setter (ReceivableFlow d bal p i ppy def recovery loss _) mStat
       = ReceivableFlow d bal p i ppy def recovery loss mStat
     setter x _ = x
+
+
 
 
 $(deriveJSON defaultOptions ''TsRow)

--- a/src/Deal.hs
+++ b/src/Deal.hs
@@ -77,30 +77,68 @@ import InterestRate (calcInt)
 import Liability (getDayCountFromInfo)
 import Hedge (RateCap(..),RateSwapBase(..),RateSwap(rsRefBalance))
 import qualified Hedge as HE
+import Types (DayCount(DC_ACT_365F))
 
 debug = flip trace
 
 -- ^ update bond interest rate from rate assumption
 setBondNewRate :: Ast.Asset a => TestDeal a -> Date -> [RateAssumption] -> L.Bond -> Either String L.Bond
-setBondNewRate t d ras b@(L.Bond _ _ _ ii (Just (L.PassDateSpread _ spd)) bal currentRate _ dueInt _ (Just dueIntDate) _ _ _)
+setBondNewRate t d ras b@(L.Bond _ _ L.OriginalInfo{ L.originDate = od} ii _ bal currentRate _ dueInt _ Nothing _ _ _)
+  = setBondNewRate t d ras b {L.bndDueIntDate = Just od}
+
+
+-- ^ Floater rate+step up(once)
+setBondNewRate t d ras b@(L.Bond _ _ _ ii@(L.Floater br idx _spd rset dc mf mc) (Just (L.PassDateSpread resetDay spd)) bal currentRate _ dueInt _ (Just dueIntDate) _ _ _)
+  | resetDay == d = Right $ b { L.bndRate = currentRate + spd, L.bndDueInt = dueInt + accrueInt
+                              , L.bndDueIntDate = Just d
+                              , L.bndInterestInfo = L.Floater br idx (_spd+spd) rset dc mf mc}
+  | otherwise = Right $ b { L.bndRate = applyFloatRate ii d ras 
+                      , L.bndDueInt = dueInt + accrueInt, L.bndDueIntDate = Just d}
+    where 
+      (Just dc) = getDayCountFromInfo ii
+      accrueInt = calcInt (bal + dueInt) dueIntDate d currentRate dc
+
+-- ^ Floater rate+step up(ladder) TODO ,it's not ladder
+setBondNewRate t d ras b@(L.Bond _ _ _ ii@(L.Floater br idx _spd rset dc mf mc) (Just (L.PassDateSpread resetDay spd)) bal currentRate _ dueInt _ (Just dueIntDate) _ _ _)
+  | resetDay == d = Right $ b { L.bndRate = currentRate + spd, L.bndDueInt = dueInt + accrueInt
+                              , L.bndDueIntDate = Just d
+                              , L.bndInterestInfo = L.Floater br idx (_spd+spd) rset dc mf mc}
+  | otherwise = Right $ b { L.bndRate = applyFloatRate ii d ras 
+                      , L.bndDueInt = dueInt + accrueInt, L.bndDueIntDate = Just d}
+    where 
+      (Just dc) = getDayCountFromInfo ii
+      accrueInt = calcInt (bal + dueInt) dueIntDate d currentRate dc
+
+-- ^ Fix rate+step up(once)
+setBondNewRate t d ras b@(L.Bond _ _ _ ii@(L.Fix {}) (Just (L.PassDateSpread resetDay spd)) bal currentRate _ dueInt _ (Just dueIntDate) _ _ _)
+  | resetDay == d = Right $ b { L.bndRate = currentRate + spd, L.bndDueInt = dueInt + accrueInt, L.bndDueIntDate = Just d}
+  | otherwise = Right b
+    where 
+      (Just dc) = getDayCountFromInfo ii
+      accrueInt = calcInt (bal + dueInt) dueIntDate d currentRate dc
+
+-- ^ Fix rate+step up(ladder)
+setBondNewRate t d ras b@(L.Bond _ _ _ ii@(L.Fix {}) (Just (L.PassDateLadderSpread _ spd _)) bal currentRate _ dueInt _ (Just dueIntDate) _ _ _)
   = Right $ b { L.bndRate = currentRate + spd, L.bndDueInt = dueInt + accrueInt, L.bndDueIntDate = Just d}
     where 
       (Just dc) = getDayCountFromInfo ii
       accrueInt = calcInt (bal + dueInt) dueIntDate d currentRate dc
 
-setBondNewRate t d ras b@(L.Bond _ _ _ ii (Just (L.PassDateLadderSpread _ spd _)) bal currentRate _ dueInt _ (Just dueIntDate) _ _ _)
-  = Right $ b { L.bndRate = currentRate + spd, L.bndDueInt = dueInt + accrueInt, L.bndDueIntDate = Just d}
-    where 
-      (Just dc) = getDayCountFromInfo ii
-      accrueInt = calcInt (bal + dueInt) dueIntDate d currentRate dc
-
-setBondNewRate t d ras b@(L.Bond _ _ _ (L.RefRate sr ds factor _) _ _ _ _ _ _ _ _ _ _) 
+-- ^ Ref rate
+setBondNewRate t d ras b@(L.Bond _ _ _ (L.RefRate sr ds factor _) _ bal currentRate _ dueInt _ (Just dueIntDate) _ _ _) 
   = do
       rate <- queryCompound t d (patchDateToStats d ds)
-      return b {L.bndRate = fromRational (toRational rate * toRational factor) }
-
-setBondNewRate t d ras b@(L.Bond _ _ _ ii _ _ _ _ _ _ _ _ _ _) 
-  = Right $ b { L.bndRate = applyFloatRate ii d ras }
+      let accrueInt = calcInt (bal + dueInt) dueIntDate d (fromRational rate) DC_ACT_365F
+      return b {L.bndRate = fromRational (rate * toRational factor) 
+                ,L.bndDueInt = dueInt + accrueInt, L.bndDueIntDate = Just d}
+      
+-- ^ floater bond
+setBondNewRate t d ras b@(L.Bond _ _ _ ii@(L.Floater br idx _spd rset dc mf mc) _ bal currentRate _ dueInt _ (Just dueIntDate) _ _ _) 
+  = Right $ b { L.bndRate = applyFloatRate ii d ras 
+              , L.bndDueInt = dueInt + accrueInt, L.bndDueIntDate = Just d}
+    where 
+      (Just dc) = getDayCountFromInfo ii
+      accrueInt = calcInt (bal + dueInt) dueIntDate d currentRate dc
 
 setBondNewRate t d ras bg@(L.BondGroup bMap)
   = do 

--- a/src/Deal.hs
+++ b/src/Deal.hs
@@ -403,27 +403,27 @@ run t@TestDeal{accounts=accMap,fees=feeMap,triggers=mTrgMap,bonds=bndMap,status=
           if any (> 0) remainCollectionNum then
             let 
               cutOffPoolFlowMap = Map.map (\pflow -> CF.splitCashFlowFrameByDate pflow d EqToLeft) poolFlowMap 
-              collectedFlow =  Map.map fst cutOffPoolFlowMap  `debug` ("PoolCollection : "++ show d ++  " splited"++ show cutOffPoolFlowMap++"\n input pflow"++ show poolFlowMap)
+              collectedFlow =  Map.map fst cutOffPoolFlowMap  -- `debug` ("PoolCollection : "++ show d ++  " splited"++ show cutOffPoolFlowMap++"\n input pflow"++ show poolFlowMap)
               -- outstandingFlow = Map.map (CF.insertBegTsRow d . snd) cutOffPoolFlowMap
               outstandingFlow = Map.map snd cutOffPoolFlowMap
               -- deposit cashflow to SPV from external pool cf               
             in 
               do 
-                let accs = depositPoolFlow (collects t) d collectedFlow accMap  `debug` ("PoolCollection: deposit >>"++ show d++">>>"++ show collectedFlow++"\n")
+                let accs = depositPoolFlow (collects t) d collectedFlow accMap -- `debug` ("PoolCollection: deposit >>"++ show d++">>>"++ show collectedFlow++"\n")
                 let dAfterDeposit = (appendCollectedCF d t collectedFlow) {accounts=accs}   -- `debug` ("Collected flow"++ show collectedFlow)
                 -- newScheduleFlowMap = Map.map (over CF.cashflowTxn (cutBy Exc Future d)) (fromMaybe Map.empty (getScheduledCashflow t Nothing))
                 let dealAfterUpdateScheduleFlow = over dealScheduledCashflow 
                                                     (Map.map (\mflow -> over CF.cashflowTxn (cutBy Exc Future d) <$> mflow))
                                                     dAfterDeposit 
-                let runContext = RunContext outstandingFlow rAssump rates  `debug` ("PoolCollection: before rc >>"++ show d++">>>"++ show (pool dAfterDeposit))
-                (dRunWithTrigger0, rc1,ads2, newLogs0) <- runTriggers (dealAfterUpdateScheduleFlow,runContext,ads) d EndCollection  `debug` ("PoolCollection: after update schedule flow >>"++ show d++">>"++show (pool dealAfterUpdateScheduleFlow))
+                let runContext = RunContext outstandingFlow rAssump rates  -- `debug` ("PoolCollection: before rc >>"++ show d++">>>"++ show (pool dAfterDeposit))
+                (dRunWithTrigger0, rc1,ads2, newLogs0) <- runTriggers (dealAfterUpdateScheduleFlow,runContext,ads) d EndCollection  -- `debug` ("PoolCollection: after update schedule flow >>"++ show d++">>"++show (pool dealAfterUpdateScheduleFlow))
                 let eopActionsLog = [ RunningWaterfall d W.EndOfPoolCollection | Map.member W.EndOfPoolCollection waterfallM ] -- `debug` ("new logs from trigger 1"++ show newLogs0)
                 let waterfallToExe = Map.findWithDefault [] W.EndOfPoolCollection (waterfall t)  -- `debug` ("new logs from trigger 1"++ show newLogs0)
                 (dAfterAction,rc2,newLogs) <- foldM (performActionWrap d) (dRunWithTrigger0 ,rc1 ,log ) waterfallToExe  -- `debug` ("Pt 03"++ show d++">> context flow"++show (pool dRunWithTrigger0))-- `debug` ("End collection action"++ show waterfallToExe)
-                (dRunWithTrigger1,rc3,ads3,newLogs1) <- runTriggers (dAfterAction,rc2,ads2) d EndCollectionWF `debug` ("PoolCollection: Pt 04"++ show d++">> context flow"++show (runPoolFlow rc2))-- `debug` ("End collection action"++ show waterfallToExe)
-                run dRunWithTrigger1 (runPoolFlow rc3) (Just ads3) rates calls rAssump (newLogs0++newLogs++ eopActionsLog ++newLogs1) `debug` ("PoolCollection: Pt 05>> "++ show d++">> context flow>> "++show (runPoolFlow rc3))
+                (dRunWithTrigger1,rc3,ads3,newLogs1) <- runTriggers (dAfterAction,rc2,ads2) d EndCollectionWF -- `debug` ("PoolCollection: Pt 04"++ show d++">> context flow"++show (runPoolFlow rc2))-- `debug` ("End collection action"++ show waterfallToExe)
+                run dRunWithTrigger1 (runPoolFlow rc3) (Just ads3) rates calls rAssump (newLogs0++newLogs++ eopActionsLog ++newLogs1) -- `debug` ("PoolCollection: Pt 05>> "++ show d++">> context flow>> "++show (runPoolFlow rc3))
           else
-            run t poolFlowMap (Just ads) rates calls rAssump log `debug` ("PoolCollection: hit zero pool length"++ show d++"pool"++ (show poolFlowMap)++"collected cf"++ show pt) 
+            run t poolFlowMap (Just ads) rates calls rAssump log -- `debug` ("PoolCollection: hit zero pool length"++ show d++"pool"++ (show poolFlowMap)++"collected cf"++ show pt) 
    
         RunWaterfall d _ ->
           let
@@ -452,8 +452,8 @@ run t@TestDeal{accounts=accMap,fees=feeMap,triggers=mTrgMap,bonds=bndMap,status=
                   return (prepareDeal dealAfterCleanUp, endingLogs ++ logsBeforeDist ++newStLogs++[EndRun (Just d) "Clean Up"]) -- `debug` ("Called ! "++ show d)
               else
                 do
-                  (dAfterWaterfall, rc2, newLogsWaterfall) <- foldM (performActionWrap d) (dRunWithTrigger0,rc1,log) waterfallToExe `debug` ("In RunWaterfall Date"++show d++">>> status "++show (status dRunWithTrigger0)++"before run waterfall collected >>"++ show (pool dRunWithTrigger0))
-                  (dRunWithTrigger1, rc3, ads2, newLogs2) <- runTriggers (dAfterWaterfall,rc2,ads1) d EndDistributionWF  `debug` ("In RunWaterfall Date"++show d++"after run waterfall >>"++ show (runPoolFlow rc2)++" collected >>"++ show (pool dAfterWaterfall))
+                  (dAfterWaterfall, rc2, newLogsWaterfall) <- foldM (performActionWrap d) (dRunWithTrigger0,rc1,log) waterfallToExe -- `debug` ("In RunWaterfall Date"++show d++">>> status "++show (status dRunWithTrigger0)++"before run waterfall collected >>"++ show (pool dRunWithTrigger0))
+                  (dRunWithTrigger1, rc3, ads2, newLogs2) <- runTriggers (dAfterWaterfall,rc2,ads1) d EndDistributionWF  -- `debug` ("In RunWaterfall Date"++show d++"after run waterfall >>"++ show (runPoolFlow rc2)++" collected >>"++ show (pool dAfterWaterfall))
                   run dRunWithTrigger1 (runPoolFlow rc3) (Just ads2) rates calls rAssump (newLogsWaterfall++newLogs2++logsBeforeDist++[RunningWaterfall d waterfallKey]) -- `debug` ("In RunWaterfall Date"++show d++"after run waterfall 3>>"++ show (pool dRunWithTrigger1)++" status>>"++ show (status dRunWithTrigger1))
 
         EarnAccInt d accName ->

--- a/src/Deal/DealAction.hs
+++ b/src/Deal/DealAction.hs
@@ -760,11 +760,11 @@ performAction d t@TestDeal{ledgers= Just ledgerM} (W.BookBy (W.PDL dr ds ledgers
     do
       amtToBook <- queryCompound t d ds
       ledgCaps <- ledgerCaps
-      let amtBookedToLedgers = paySeqLiabilitiesAmt (fromRational amtToBook) (fromRational <$> ledgCaps)
+      let amtBookedToLedgers = paySeqLiabilitiesAmt (fromRational amtToBook) (fromRational <$> ledgCaps) --`debug` ("amt to book"++ show amtToBook)
       let newLedgerM = foldr 
                          (\(ln,amt) acc -> Map.adjust (LD.entryLogByDr dr amt d Nothing) ln acc)
                          ledgerM
-                         (zip ledgerNames amtBookedToLedgers)
+                         (zip ledgerNames amtBookedToLedgers) --`debug` ("amts to book"++ show amtBookedToLedgers)
       return $ t {ledgers = Just newLedgerM}
 
 -- ^ pay fee sequentially
@@ -832,7 +832,8 @@ performAction d t@TestDeal{bonds=bndMap, accounts=accMap, liqProvider=liqMap}
         return $ updateSupport d mSupport supportPaidOut dealAfterAcc
 
 
-performAction d t@TestDeal{bonds=bndMap, accounts=accMap, liqProvider=liqMap} (W.PayIntBySeq mLimit an bnds mSupport)
+performAction d t@TestDeal{bonds=bndMap, accounts=accMap, liqProvider=liqMap} 
+              (W.PayIntBySeq mLimit an bnds mSupport)
    = let 
       availAccBal = A.accBalance (accMap Map.! an)
       bndsList = (Map.!) bndMap <$> bnds

--- a/src/Deal/DealAction.hs
+++ b/src/Deal/DealAction.hs
@@ -586,9 +586,9 @@ performActionWrap d
                             (StaticAsset _) -> min availBal valuationOnAvailableAssets -- `debug` ("Valuation on rpool"++show valuationOnAvailableAssets)
                             ConstantAsset _ -> availBal 
                             AssetCurve _ -> min availBal valuationOnAvailableAssets   
-        let purchaseRatio = divideBB purchaseAmt valuationOnAvailableAssets `debug` ("In Buy >>> Date"++ show d ++ " Purchase Amt"++show purchaseAmt++">> avail value on availAsset"++ show  valuationOnAvailableAssets )
-        let (assetBought,poolAfterBought) = buyRevolvingPool d (toRational purchaseRatio) assetForSale  `debug` ("In Buy >>> date "++ show d ++ "purchase ratio"++ show purchaseRatio)
-        let boughtAssetBal =  sum $ curBal <$> assetBought  `debug` ("In Buy >>> Asset bought 0 \n"++ show assetBought++ "pflow map\n"++ show pFlowMap++" p id to change\n"++ show pIdToChange)
+        let purchaseRatio = divideBB purchaseAmt valuationOnAvailableAssets -- `debug` ("In Buy >>> Date"++ show d ++ " Purchase Amt"++show purchaseAmt++">> avail value on availAsset"++ show  valuationOnAvailableAssets )
+        let (assetBought,poolAfterBought) = buyRevolvingPool d (toRational purchaseRatio) assetForSale  -- `debug` ("In Buy >>> date "++ show d ++ "purchase ratio"++ show purchaseRatio)
+        let boughtAssetBal =  sum $ curBal <$> assetBought  -- `debug` ("In Buy >>> Asset bought 0 \n"++ show assetBought++ "pflow map\n"++ show pFlowMap++" p id to change\n"++ show pIdToChange)
         -- update runtime balance
         let newPt = case pt of 
                       MultiPool pm -> MultiPool $ Map.adjust
@@ -599,11 +599,11 @@ performActionWrap d
 
         let newAccMap = Map.adjust (A.draw purchaseAmt d (PurchaseAsset revolvingPoolName boughtAssetBal)) accName accsMap -- `debug` ("Asset bought total bal"++ show boughtAssetBal)
         cfFrameBought <- projAssetUnionList [updateOriginDate2 d ast | ast <- assetBought ] d perfAssumps mRates  -- `debug` ("Date: " ++ show d ++ "Asset bought"++ show [updateOriginDate2 d ast | ast <- assetBought ])
-        let cfBought = fst cfFrameBought `debug` ("In Buy>>>"++ show d ++"Cf bought"++ show (fst cfFrameBought))
+        let cfBought = fst cfFrameBought -- `debug` ("In Buy>>>"++ show d ++"Cf bought"++ show (fst cfFrameBought))
         let newPcf = Map.adjust (\cfOrigin@(CF.CashFlowFrame st trs) -> 
                                 let 
                                   dsInterval = getDate <$> trs  --  `debug` ("Date"++ show d ++ "origin cf \n"++ show cfOrigin)
-                                  boughtCfDates = getDate <$> view CF.cashflowTxn cfBought  `debug` ("In Buy>>>"++"Date"++ show d++ "Cf bought 0\n"++ show cfBought)
+                                  boughtCfDates = getDate <$> view CF.cashflowTxn cfBought -- `debug` ("In Buy>>>"++"Date"++ show d++ "Cf bought 0\n"++ show cfBought)
 
                                   newAggDates = case (dsInterval,boughtCfDates) of 
                                                   ([],[]) -> []
@@ -621,11 +621,11 @@ performActionWrap d
 
                                   mergedCf = CF.mergePoolCf2 cfOrigin cfBought -- `debug` ("Buy Date : "++show d ++ "CF bought \n"++ show (over CF.cashflowTxn (slice 0 30) cfBought) )
                                 in 
-                                  over CF.cashflowTxn (`CF.aggTsByDates` (dsInterval ++ newAggDates)) mergedCf  `debug` ("In Buy>>>"++"Date "++show d++" Merged CF\n"++ show mergedCf))
+                                  over CF.cashflowTxn (`CF.aggTsByDates` (dsInterval ++ newAggDates)) mergedCf )-- `debug` ("In Buy>>>"++"Date "++show d++" Merged CF\n"++ show mergedCf))
                             pIdToChange
                             pFlowMap --  `debug` ("pid To change"++ show pIdToChange++ "P flow map"++ show pFlowMap)
 
-        let newRc = rc {runPoolFlow = newPcf  `debug` ("In Buy>>>"++show d ++ "New run pool >> \n"++ show newPcf)
+        let newRc = rc {runPoolFlow = newPcf  -- `debug` ("In Buy>>>"++show d ++ "New run pool >> \n"++ show newPcf)
                         ,revolvingAssump = Just (Map.insert revolvingPoolName (poolAfterBought, perfAssumps) rMap)} 
         return (t { accounts = newAccMap , pool = newPt}, newRc, logs)
 

--- a/src/Deal/DealAction.hs
+++ b/src/Deal/DealAction.hs
@@ -680,8 +680,8 @@ performActionWrap d
      -- REMOVE future cf
      newPfInRc = foldr (Map.adjust (set CF.cashflowTxn [])) pcf  (Map.keys poolMapToLiq)
      -- Update current balance to zero 
-   in 
-     Right (t {accounts = accMapAfterLiq , pool = newPt} , rc {runPoolFlow = newPfInRc}, logs )
+   in
+     Right (t {accounts = accMapAfterLiq , pool = newPt} , rc {runPoolFlow = newPfInRc}, logs)
 
 
 performActionWrap d (t, rc, logs) (W.WatchVal ms dss)
@@ -718,12 +718,10 @@ performActionWrap d (t, rc, logs) (W.ChangeStatus mPre newSt)
             return (t, rc, logs)
 
 -- ^ go down to performAction
-
 performActionWrap d (t, rc, logs) a 
   = do 
       dealAfterExe <- performAction d t a 
       return (dealAfterExe, rc, logs)
-
 
 performAction :: Ast.Asset a => Date -> TestDeal a -> W.Action -> Either String (TestDeal a)
 performAction d t@TestDeal{accounts=accMap, ledgers = Just ledgerM} 

--- a/src/Deal/DealBase.hs
+++ b/src/Deal/DealBase.hs
@@ -214,6 +214,10 @@ data PoolType a = MultiPool (Map.Map PoolId (P.Pool a))
                 | ResecDeal (Map.Map PoolId (UnderlyingDeal a))
                 deriving (Generic, Eq, Ord, Show)
 
+
+
+
+
 data TestDeal a = TestDeal { name :: DealName
                              ,status :: DealStatus
                              ,dates :: DateDesp

--- a/src/Deal/DealBase.hs
+++ b/src/Deal/DealBase.hs
@@ -473,7 +473,7 @@ getAllCollectedFrame t mPid =
     mCf = view dealCashflow t
   in 
     case mPid of 
-      Nothing -> mCf -- `debug` ("Nothing when collecting cfs"++show mCf)
+      Nothing -> mCf  -- `debug` ("Nothing when collecting cfs"++show mCf)
       Just pids -> Map.filterWithKey (\k _ -> k `elem` pids) mCf -- `debug` ("Just when collecting cfs"++show mCf)
 
 getLatestCollectFrame :: Ast.Asset a => TestDeal a -> Maybe [PoolId] -> Map.Map PoolId (Maybe CF.TsRow)

--- a/src/Deal/DealBase.hs
+++ b/src/Deal/DealBase.hs
@@ -199,7 +199,7 @@ uDealFutureCf = lens getter setter
 uDealFutureTxn :: Ast.Asset a => Lens' (UnderlyingDeal a) [CF.TsRow]
 uDealFutureTxn = lens getter setter
   where 
-    getter ud = fromMaybe [] $ CF.getTsCashFlowFrame <$> futureCf ud
+    getter ud = fromMaybe [] $ (view CF.cashflowTxn) <$> futureCf ud
     setter ud newTxn = 
         let 
            mOriginalCfFrame = futureCf ud 

--- a/src/Deal/DealQuery.hs
+++ b/src/Deal/DealQuery.hs
@@ -206,7 +206,7 @@ queryDeal t@TestDeal{accounts=accMap, bonds=bndMap, fees=feeMap, ledgers=ledgerM
               bs Credit = filter (<0) $ LD.ledgBalance . (ledgersM Map.!) <$> ans
               bs Debit = filter (>0) $ LD.ledgBalance . (ledgersM Map.!) <$> ans
             in 
-              sum (bs dr) -- `debug` ("dr"++show dr++">> bs dr"++ show (bs dr))
+              abs $ sum (bs dr) -- `debug` ("dr"++show dr++">> bs dr"++ show (bs dr))
 
     FutureCurrentPoolBalance mPns ->
       case (mPns,pt) of 

--- a/src/Deal/DealQuery.hs
+++ b/src/Deal/DealQuery.hs
@@ -69,41 +69,41 @@ calcTargetAmount t d (A.Account _ _ _ (Just r) _ ) =
 
 patchDateToStats :: Date -> DealStats -> DealStats
 patchDateToStats d t
-   = case t of
-         CurrentPoolBalance mPns -> FutureCurrentPoolBalance mPns
-         CurrentPoolBegBalance mPns -> FutureCurrentPoolBegBalance mPns
-         PoolFactor mPns -> FutureCurrentPoolFactor d mPns
-         LastBondIntPaid bns -> BondsIntPaidAt d bns
-         LastFeePaid fns -> FeesPaidAt d fns
-         LastBondPrinPaid bns -> BondsPrinPaidAt d bns
-         BondBalanceGap bn -> BondBalanceGapAt d bn
-         ReserveGap ans -> ReserveGapAt d ans
-         ReserveExcess ans -> ReserveExcessAt d ans
-         Sum _ds -> Sum $ map (patchDateToStats d) _ds
-         Substract _ds -> Substract $ map (patchDateToStats d) _ds
-         Subtract _ds -> Subtract $ map (patchDateToStats d) _ds
-         Min dss -> Min $ [ patchDateToStats d ds | ds <- dss ] 
-         Max dss -> Max $ [ patchDateToStats d ds | ds <- dss ]
-         Factor _ds r -> Factor (patchDateToStats d _ds) r
-         FloorWithZero ds -> FloorWithZero (patchDateToStats d ds) 
-         UseCustomData n -> CustomData n d
-         CurrentPoolBorrowerNum mPns -> FutureCurrentPoolBorrowerNum d mPns
-         FeeTxnAmt ns mCmt -> FeeTxnAmtBy d ns mCmt
-         BondTxnAmt ns mCmt -> BondTxnAmtBy d ns mCmt
-         AccTxnAmt ns mCmt -> AccTxnAmtBy d ns mCmt -- `debug` ("Hitttt")
-         PoolScheduleCfPv pm pns -> FuturePoolScheduleCfPv d pm pns
-         Excess dss -> Excess $ [ patchDateToStats d ds | ds <- dss ]
-         Abs ds -> Abs $ patchDateToStats d ds
-         Avg dss -> Avg $ [ patchDateToStats d ds | ds <- dss ]
-         Divide ds1 ds2 -> Divide (patchDateToStats d ds1) (patchDateToStats d ds2)
-         FloorAndCap f c s -> FloorAndCap (patchDateToStats d f) (patchDateToStats d c) (patchDateToStats d s)
-         Multiply dss -> Multiply $ [ patchDateToStats d ds | ds <- dss ]
-         FloorWith ds f -> FloorWith (patchDateToStats d ds) (patchDateToStats d f)
-         CapWith ds c -> CapWith (patchDateToStats d ds) (patchDateToStats d c)
-         Round ds rb -> Round (patchDateToStats d ds) rb
-         DivideRatio ds1 ds2 -> DivideRatio (patchDateToStats d ds1) (patchDateToStats d ds2)
-         AvgRatio ss -> AvgRatio $ [ patchDateToStats d ds | ds <- ss ]
-         _ -> t -- `debug` ("Failed to patch date to stats"++show t)
+  = case t of
+      CurrentPoolBalance mPns -> FutureCurrentPoolBalance mPns
+      CurrentPoolBegBalance mPns -> FutureCurrentPoolBegBalance mPns
+      PoolFactor mPns -> FutureCurrentPoolFactor d mPns
+      LastBondIntPaid bns -> BondsIntPaidAt d bns
+      LastFeePaid fns -> FeesPaidAt d fns
+      LastBondPrinPaid bns -> BondsPrinPaidAt d bns
+      BondBalanceGap bn -> BondBalanceGapAt d bn
+      ReserveGap ans -> ReserveGapAt d ans
+      ReserveExcess ans -> ReserveExcessAt d ans
+      Sum _ds -> Sum $ map (patchDateToStats d) _ds
+      Substract _ds -> Substract $ map (patchDateToStats d) _ds
+      Subtract _ds -> Subtract $ map (patchDateToStats d) _ds
+      Min dss -> Min $ [ patchDateToStats d ds | ds <- dss ] 
+      Max dss -> Max $ [ patchDateToStats d ds | ds <- dss ]
+      Factor _ds r -> Factor (patchDateToStats d _ds) r
+      FloorWithZero ds -> FloorWithZero (patchDateToStats d ds) 
+      UseCustomData n -> CustomData n d
+      CurrentPoolBorrowerNum mPns -> FutureCurrentPoolBorrowerNum d mPns
+      FeeTxnAmt ns mCmt -> FeeTxnAmtBy d ns mCmt
+      BondTxnAmt ns mCmt -> BondTxnAmtBy d ns mCmt
+      AccTxnAmt ns mCmt -> AccTxnAmtBy d ns mCmt -- `debug` ("Hitttt")
+      PoolScheduleCfPv pm pns -> FuturePoolScheduleCfPv d pm pns
+      Excess dss -> Excess $ [ patchDateToStats d ds | ds <- dss ]
+      Abs ds -> Abs $ patchDateToStats d ds
+      Avg dss -> Avg $ [ patchDateToStats d ds | ds <- dss ]
+      Divide ds1 ds2 -> Divide (patchDateToStats d ds1) (patchDateToStats d ds2)
+      FloorAndCap f c s -> FloorAndCap (patchDateToStats d f) (patchDateToStats d c) (patchDateToStats d s)
+      Multiply dss -> Multiply $ [ patchDateToStats d ds | ds <- dss ]
+      FloorWith ds f -> FloorWith (patchDateToStats d ds) (patchDateToStats d f)
+      CapWith ds c -> CapWith (patchDateToStats d ds) (patchDateToStats d c)
+      Round ds rb -> Round (patchDateToStats d ds) rb
+      DivideRatio ds1 ds2 -> DivideRatio (patchDateToStats d ds1) (patchDateToStats d ds2)
+      AvgRatio ss -> AvgRatio $ [ patchDateToStats d ds | ds <- ss ]
+      _ -> t -- `debug` ("Failed to patch date to stats"++show t)
 
 patchDatesToStats :: P.Asset a => TestDeal a -> Date -> Date -> DealStats -> DealStats
 patchDatesToStats t d1 d2 ds 
@@ -397,16 +397,16 @@ queryCompound t@TestDeal{accounts=accMap, bonds=bndMap, ledgers=ledgersM, fees=f
         Right . toRational $ futureVals + historyVals
     
     PoolCumCollectionTill idx ps mPns -> 
-        let 
-          txnMap = Map.map (dropLastN (negate idx) . fromMaybe []) $ getAllCollectedTxns t mPns 
-          txnList = concat $ Map.elems txnMap
-          lookupList = CF.lookupSource <$> txnList
-          futureVals = sum $ lookupList <*> ps
-          sumMap = getIssuanceStatsConsol t mPns
-          historyVals = sum $ Map.findWithDefault 0 . poolSourceToIssuanceField <$> ps <*> [sumMap]
-        in 
-          Right . toRational $ futureVals + historyVals
- 
+      let 
+        txnMap = Map.map (dropLastN (negate idx) . fromMaybe []) $ getAllCollectedTxns t mPns 
+        txnList = concat $ Map.elems txnMap
+        lookupList = CF.lookupSource <$> txnList
+        futureVals = sum $ lookupList <*> ps
+        sumMap = getIssuanceStatsConsol t mPns
+        historyVals = sum $ Map.findWithDefault 0 . poolSourceToIssuanceField <$> ps <*> [sumMap]
+      in 
+        Right . toRational $ futureVals + historyVals
+
     PoolCurCollection ps mPns ->
       let 
         pCf = getLatestCollectFrame t mPns -- `debug` ("mPns"++ show mPns)
@@ -416,30 +416,30 @@ queryCompound t@TestDeal{accounts=accMap, bonds=bndMap, ledgers=ledgersM, fees=f
 
     PoolCollectionStats idx ps mPns -> 
       let 
-        pCollectedTxns = getAllCollectedTxns t mPns
+        pCollectedTxns = getAllCollectedTxns t mPns 
         pStat = Map.map
                   (\_x -> 
-                   let
-                     lookupIndx = length x + idx - 1
-                     x = fromMaybe [] _x
-                   in
-                     if (( lookupIndx >= length x ) ||  (lookupIndx <0)) then 
-                       Nothing
-                     else
-                       Just (x!!lookupIndx))
-                  pCollectedTxns
+                    let
+                      lookupIndx = length x + idx - 1
+                      x = fromMaybe [] _x
+                    in
+                      if (( lookupIndx >= length x ) ||  (lookupIndx <0)) then 
+                        Nothing
+                      else
+                        Just (x!!lookupIndx))
+                  pCollectedTxns `debug` ("date"++show d++"Pool collection: "++ show pCollectedTxns)
       in
         do
           curPoolBalM <- sequenceA $
                            Map.mapWithKey
                              (\k v -> queryCompound t d (FutureCurrentPoolBalance (Just [k]))) 
-                             pStat
+                             pStat `debug` ("date"++show d++"Pool stats collection: "++ show pStat)
           let poolStat = Map.mapWithKey
                            (\k v -> 
                               case v of
                                 Just _v -> sum $ CF.lookupSource _v <$> ps
                                 Nothing -> sum $ CF.lookupSourceM (fromRational (curPoolBalM Map.! k)) Nothing <$> ps)
-                           pStat -- `debug` ("query pool current bal" ++ show curPoolBalM )
+                           pStat  `debug` ("date"++show d++"query pool current pool stat 2" ++ show pStat )
           return $ sum $ Map.elems $ toRational <$> poolStat -- `debug` ("query pool current stats"++ show poolStat)
 
     FuturePoolScheduleCfPv asOfDay pm mPns -> 
@@ -457,13 +457,13 @@ queryCompound t@TestDeal{accounts=accMap, bonds=bndMap, ledgers=ledgersM, fees=f
         do 
           scheduleBal <- queryCompound t d (FutureCurrentSchedulePoolBegBalance mPns)
           curBal <- queryCompound t d (FutureCurrentPoolBalance mPns) 
-          let factor = case scheduleBal of 
+          let factor = case scheduleBal of
                          0.00 -> 0  
                          _ -> curBal / scheduleBal -- `debug` ("cur Bal"++show curBal ++">> sheduleBal"++ show scheduleBal)
           let cfForPv = (`mulBR` factor) <$> txnsCfs -- `debug` (">>> factor"++ show factor)
           let pvs = case pm of
                       PvRate r -> uncurry (A.pv2 r asOfDay) <$> zip txnsDs cfForPv
-                      -- TODO _ -> Left $ "Failed to use pricing method on pool" ++ show pm ++"on pool id"++ show mPns
+                      -- _ -> Left $ "Date:"++ show asOfDay ++ "Failed to use pricing method on pool" ++ show pm ++"on pool id"++ show mPns
           return $ toRational $ sum pvs
 
     BondsIntPaidAt d bns ->
@@ -658,7 +658,7 @@ queryDealBool t@TestDeal{triggers= trgs,bonds = bndMap} ds d =
                            case Map.lookup tName triggerMatCycle of 
                              Nothing -> Left ("Date:"++show d++"no trigger for this deal" ++ show tName ++ " in cycle " ++ show triggerMatCycle)
                              Just trigger -> Right $ Trg.trgStatus trigger 
-        Nothing -> Left "Date:"++show d++"no trigger for this deal"
+        Nothing -> Left $ "Date:"++show d++"no trigger for this deal"
     
     IsMostSenior bn bns ->
       do 
@@ -697,13 +697,10 @@ queryDealBool t@TestDeal{triggers= trgs,bonds = bndMap} ds d =
 
     IsDealStatus st -> Right $ status t == st
 
-    TestNot ds -> do 
-                    q <- (queryDealBool t ds d)
-                    return $ not q
-
+    TestNot ds -> do not <$> (queryDealBool t ds d)
     -- TestAny b dss -> b `elem` [ queryDealBool t ds d | ds <- dss ]
-    TestAny b dss -> anyM (\ x -> (== b) <$> (queryDealBool t x d) ) dss
-    TestAll b dss -> allM (\ x -> (== b) <$> (queryDealBool t x d) ) dss
+    TestAny b dss -> anyM (\ x -> (== b) <$> queryDealBool t x d ) dss
+    TestAll b dss -> allM (\ x -> (== b) <$> queryDealBool t x d ) dss
 
     _ -> Left ("Date:"++show d++"Failed to query bool type formula"++ show ds)
 

--- a/src/Deal/DealQuery.hs
+++ b/src/Deal/DealQuery.hs
@@ -201,8 +201,6 @@ queryDeal t@TestDeal{accounts=accMap, bonds=bndMap, fees=feeMap, ledgers=ledgerM
     
     FutureCurrentPoolBalance mPns ->
       case (mPns,pt) of 
-        (Just [PoolConsol], SoloPool p) -> Pl.getIssuanceField p RuntimeCurrentPoolBalance
-        (Nothing, SoloPool p) -> Pl.getIssuanceField p RuntimeCurrentPoolBalance
         (Nothing, MultiPool pm ) -> queryDeal t (FutureCurrentPoolBalance (Just $ Map.keys pm))
         (Just pids, MultiPool pm) -> 
           if S.isSubsetOf  (S.fromList pids) (S.fromList (Map.keys pm)) then 

--- a/src/Deal/DealQuery.hs
+++ b/src/Deal/DealQuery.hs
@@ -4,8 +4,8 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Deal.DealQuery (queryDealBool,queryDeal
-                       ,patchDateToStats,patchDatesToStats,testPre, calcTargetAmount, testPre2
+module Deal.DealQuery (queryDealBool ,patchDateToStats,patchDatesToStats,testPre
+                      ,calcTargetAmount, testPre2
                       ,queryCompound) 
   where
 
@@ -55,9 +55,9 @@ calcTargetAmount t d (A.Account _ _ _ (Just r) _ ) =
      eval :: A.ReserveAmount -> Either String Balance
      eval ra = case ra of
        A.PctReserve ds _rate -> do 
-                                  v <- (queryCompound t d (patchDateToStats d ds))
+                                  v <- queryCompound t d (patchDateToStats d ds)
                                   return (fromRational (v * _rate))
-       A.FixReserve amt -> Right $ amt
+       A.FixReserve amt -> Right amt
        A.Either p ra1 ra2 -> do 
                                q <- testPre d t p
                                if q then 
@@ -145,370 +145,9 @@ poolSourceToIssuanceField NewDelinquencies = HistoryDelinquency
 poolSourceToIssuanceField a = error ("Failed to match pool source when mapping to issuance field"++show a)
 
 
-queryDeal :: P.Asset a => TestDeal a -> DealStats -> Balance
-queryDeal t@TestDeal{accounts=accMap, bonds=bndMap, fees=feeMap, ledgers=ledgerM, pool=pt } s = 
-  case s of
-    CurrentBondBalance -> Map.foldr (\x acc -> getCurBalance x + acc) 0.0 bndMap
-    
-    OriginalBondBalance -> Map.foldr (\x acc -> getOriginBalance x + acc) 0.0 bndMap
-    
-    BondDuePrin bnds -> sum $ L.bndDuePrin <$> viewDealBondsByNames t bnds
-    
-    OriginalBondBalanceOf bnds -> sum $ getOriginBalance <$> viewDealBondsByNames t bnds
-
-    CurrentBondBalanceOf bns -> sum $ getCurBalance <$> viewDealBondsByNames t bns
-    
-    CurrentPoolBalance mPns ->
-      let
-        assetM = concat $ Map.elems $ getAllAsset t mPns
-      in 
-        sum $ P.getCurrentBal <$> assetM 
-    
-    CurrentPoolDefaultedBalance ->
-      foldl (\acc x -> acc + P.getCurrentBal x)
-            0.0 $
-            filter P.isDefaulted (getAllAssetList t)
-
-    DealIssuanceBalance mPns -> 
-      sum $ Map.findWithDefault 0.0 IssuanceBalance <$> Map.elems (getIssuanceStats t mPns)
-
-    OriginalPoolBalance mPns -> 
-      let 
-        statsConsol = getIssuanceStatsConsol t mPns 
-      in 
-        case Map.lookup IssuanceBalance statsConsol of 
-          Just v -> v
-          Nothing -> error "No issuance balance found in the pool, pls specify it in the pool stats map `issuanceStat`"
-    
-    UnderlyingBondBalance mBndNames -> 0
- 
-    AllAccBalance -> sum $ map A.accBalance $ Map.elems accMap 
-    
-    AccBalance ans -> sum $ A.accBalance . (accMap Map.!) <$> ans
-
-    -- ReserveBalance ans -> 
-    --
-    -- ReserveAccGapAt d ans -> 
-    --
-    -- ReserveExcessAt d ans -> 
-    
-    -- ^ negatave -> credit balance , postive -> debit balance
-    LedgerBalance ans ->
-      case ledgerM of 
-        Nothing -> error ("No ledgers were modeled , failed to find ledger:"++show ans )
-        Just ledgersM -> sum $ LD.ledgBalance . (ledgersM Map.!) <$> ans
-    
-    LedgerBalanceBy dr ans ->
-      case ledgerM of 
-        Nothing -> error ("No ledgers were modeled , failed to find ledger:"++show ans )
-        Just ledgersM -> 
-            let 
-              bs Credit = filter (<0) $ LD.ledgBalance . (ledgersM Map.!) <$> ans
-              bs Debit = filter (>0) $ LD.ledgBalance . (ledgersM Map.!) <$> ans
-            in 
-              abs $ sum (bs dr) -- `debug` ("dr"++show dr++">> bs dr"++ show (bs dr))
-
-    FutureCurrentPoolBalance mPns ->
-      case (mPns,pt) of 
-        (Nothing, MultiPool pm ) -> queryDeal t (FutureCurrentPoolBalance (Just $ Map.keys pm))
-        (Just pids, MultiPool pm) -> 
-          if S.isSubsetOf  (S.fromList pids) (S.fromList (Map.keys pm)) then 
-            let 
-              m = Map.filterWithKey (\k _ -> S.member k (S.fromList pids)) pm
-            in 
-              sum $ Map.elems $ Map.map (`Pl.getIssuanceField` RuntimeCurrentPoolBalance) m 
-          else 
-            error $ "Failed to find pool balance" ++ show pids ++ " from deal "++ show (Map.keys pm)
-        _ -> error $ "Failed to find pool" ++ show (mPns) ++","++ show pt
-
-    FutureCurrentSchedulePoolBalance mPns ->
-      let 
-        scheduleFlowM = Map.elems $ view dealScheduledCashflow t
-      in 
-        sum $ maybe 0 (CF.mflowBalance . head . view CF.cashflowTxn) <$> scheduleFlowM
-    
-    FutureCurrentSchedulePoolBegBalance mPns ->
-      let 
-        scheduleFlowM = Map.elems $ view dealScheduledCashflow t
-      in 
-        sum $ maybe 0 (CF.mflowBegBalance . head . view CF.cashflowTxn) <$> scheduleFlowM
-    
-    FutureCurrentPoolBegBalance mPns ->
-      let 
-        ltc = getLatestCollectFrame t mPns
-      in 
-        sum $ maybe 0 CF.mflowBegBalance <$> ltc 
-
-    PoolCollectionHistory incomeType fromDay asOfDay mPns ->
-      sum fieldAmts
-      where
-        mTxns = Map.elems $ getAllCollectedTxns t mPns
-        subflow = sliceBy EI fromDay asOfDay $ concat $ fromMaybe [] <$> mTxns
-        fieldAmts = map (`CF.lookupSource` incomeType) subflow  
-
-    CumulativePoolDefaultedBalance mPns ->
-        let
-          latestCollect = getLatestCollectFrame t mPns
-          futureDefaults = sum $ Map.elems $ Map.map (maybe 0 (fromMaybe 0 . CF.tsCumDefaultBal )) $ latestCollect 
-        in
-          futureDefaults -- `debug` ("future Defaults at"++ show futureDefaults ++ show latestCollect)
-
-    CumulativePoolRecoveriesBalance mPns ->
-        let
-          latestCollect = getLatestCollectFrame t mPns
-          futureRecoveries = sum $ Map.elems $ Map.map (maybe 0 (fromMaybe 0 . CF.tsCumRecoveriesBal)) $ latestCollect 
-        in
-          futureRecoveries
-    
-    CumulativeNetLoss mPns ->
-         queryDeal t (CumulativePoolDefaultedBalance mPns) - queryDeal t (CumulativePoolRecoveriesBalance mPns)
-    
-    PoolCumCollection ps mPns ->
-        let 
-          collectedTxns = concat . Map.elems $ Map.map (fromMaybe []) $ getAllCollectedTxns t mPns
-          futureVals = sum $ (CF.lookupSource <$> collectedTxns) <*> ps
-          
-          poolStats = Map.elems $ getIssuanceStats t mPns
-          historyVals = sum $ (Map.findWithDefault 0.0 . poolSourceToIssuanceField <$> ps) <*> poolStats
-        in 
-          futureVals + historyVals
-    
-    PoolCumCollectionTill idx ps mPns -> 
-        let 
-          txnMap = Map.map (dropLastN (negate idx) . fromMaybe []) $ getAllCollectedTxns t mPns 
-          txnList = concat $ Map.elems txnMap
-          lookupList = CF.lookupSource <$> txnList
-          futureVals = sum $ lookupList <*> ps
-          sumMap = getIssuanceStatsConsol t mPns
-          historyVals = sum $ Map.findWithDefault 0 . poolSourceToIssuanceField <$> ps <*> [sumMap]
-        in 
-          futureVals + historyVals
- 
-    PoolCurCollection ps mPns ->
-      let 
-        pCf = getLatestCollectFrame t mPns -- `debug` ("mPns"++ show mPns)
-        lastRows = Map.map (maybe 0 (\r -> sum (CF.lookupSource r <$> ps))) pCf -- `debug` ("Latest collect frame"++ show pCf)
-      in 
-        sum $ Map.elems lastRows -- `debug   ` ("lst row found"++ show lastRows)
-
-    PoolCollectionStats idx ps mPns -> 
-      let 
-        pCollectedTxns = getAllCollectedTxns t mPns
-        pStat = Map.map
-                  (\_x -> 
-                   let
-                     lookupIndx = length x + idx - 1
-                     x = fromMaybe [] _x
-                   in
-                     if (( lookupIndx >= length x ) ||  (lookupIndx <0)) then 
-                       Nothing
-                     else
-                       Just (x!!lookupIndx))
-                  pCollectedTxns
-
-        curPoolBalM = Map.mapWithKey 
-                       (\k v ->
-                           queryDeal t (FutureCurrentPoolBalance (Just [k]))) 
-                       pStat
-        poolStat = Map.mapWithKey 
-                     (\k v -> 
-                        case v of
-                          Just _v -> sum $ CF.lookupSource _v <$> ps
-                          Nothing -> sum $ CF.lookupSourceM (curPoolBalM Map.! k) Nothing <$> ps
-                     )
-                     pStat -- `debug` ("query pool current bal" ++ show curPoolBalM )
-      in 
-        sum $ Map.elems poolStat -- `debug` ("query pool current stats"++ show poolStat)
-
-    FuturePoolScheduleCfPv asOfDay pm mPns -> 
-      let 
-        pScheduleFlow = view dealScheduledCashflow t
-        pCfTxns = Map.map (maybe [] (view CF.cashflowTxn)) $
-                    case mPns of 
-                      Nothing -> pScheduleFlow
-                      Just pIds -> Map.filterWithKey (\k _ -> S.member k (S.fromList pIds)) pScheduleFlow
-        txns = cutBy Exc Future asOfDay $ concat $ Map.elems pCfTxns
-        txnsCfs = CF.tsTotalCash <$> txns -- `debug` ("schedule cf as of "++ show asOfDay ++ ">>" ++ show txns)
-        txnsDs = getDate <$> txns
-        txnsRates = CF.mflowRate <$> txns
-        scheduleBal = queryDeal t (FutureCurrentSchedulePoolBegBalance mPns)
-        curBal = queryDeal t (FutureCurrentPoolBalance mPns) 
-        factor = case scheduleBal of 
-                   0.00 -> 0  
-                   _ -> curBal / scheduleBal -- `debug` ("cur Bal"++show curBal ++">> sheduleBal"++ show scheduleBal)
-        cfForPv = (factor *) <$> txnsCfs -- `debug` (">>> factor"++ show factor)
-        pvs = case pm of
-                PvRate r -> uncurry (A.pv2 r asOfDay) <$> zip txnsDs cfForPv
-                -- PvByRef ds -> uncurry (A.pv2 (queryCompound t asOfDay ds) asOfDay) <$> zip txnsDs cfForPv
-                _ -> error $ "Failed to use pricing method on pool" ++ show pm ++"on pool id"++ show mPns
-      in 
-        sum pvs -- `debug` ("pvs"++ show pvs)
-
-    BondsIntPaidAt d bns ->
-       let
-          stmts = map L.bndStmt $ viewDealBondsByNames t bns
-          ex s = case s of
-                   Nothing -> 0
-                   Just (Statement txns) 
-                     -> sum $ map getTxnAmt $
-                          filter (\y -> case getTxnComment y of 
-                                          (PayInt _ ) -> True
-                                          _ -> False)   $
-                          filter (\x -> d == getDate x) txns
-       in
-          sum $ map ex stmts
-
-    BondsPrinPaidAt d bns ->
-       let
-          stmts = map L.bndStmt $ viewDealBondsByNames t bns
-          ex s = case s of
-                   Nothing -> 0
-                   Just (Statement txns) 
-                     -> sum $ map getTxnAmt $
-                          filter (\y -> case getTxnComment y of 
-                                          (PayPrin _ ) -> True
-                                          _ -> False)   $
-                          filter (\x -> d == getDate x) txns
-       in
-          sum $ map ex stmts
-    
-    FeeTxnAmtBy d fns mCmt -> 
-      let 
-        fees = (feeMap Map.!) <$> fns -- Map.elems $ getFeeByName t (Just fns)
-      in  
-        case mCmt of 
-          Just cmt -> sum [ queryTxnAmtAsOf fee d cmt | fee <- fees ]
-          Nothing -> 
-            let 
-              _txn = concat [ getTxns (F.feeStmt fee) | fee <- fees ]
-            in 
-              sumTxn $ cutBy Inc Past d _txn 
-    
-    BondTxnAmtBy d bns mCmt -> 
-      let 
-        bnds = viewDealBondsByNames t bns
-      in 
-        case mCmt of
-          Just cmt -> sum [ queryTxnAmtAsOf bnd d cmt | bnd <- bnds ]
-          Nothing ->
-            let 
-              _txn = concat [ getTxns (L.bndStmt bnd) | bnd <- bnds ]
-            in 
-              sumTxn $ cutBy Inc Past d _txn
-
-    AccTxnAmtBy d ans mCmt -> 
-      let 
-        accs = (accMap Map.!) <$> ans
-      in 
-        case mCmt of
-          Just cmt -> sum [ queryTxnAmtAsOf acc d cmt | acc <- accs ]
-          Nothing ->
-            let 
-              _txn = concat [ getTxns (A.accStmt acc) | acc <- accs ]
-            in 
-              sumTxn $ cutBy Inc Past d _txn 
-
-    LedgerTxnAmt lns mCmt ->
-      case ledgerM of 
-        Nothing -> error ("No ledgers were modeled , failed to find ledger:"++show lns )
-        Just ledgerm ->
-          let 
-            lgs = (ledgerm Map.!) <$> lns
-          in
-            case mCmt of
-              Just cmt -> sum [ queryTxnAmt lg cmt | lg <- lgs ]
-              Nothing -> sum [ LD.ledgBalance lg | lg <- lgs ]
-
-    BondBalanceGapAt d bName -> 
-        let 
-           bn@L.Bond{L.bndType = L.PAC _target} = bndMap Map.! bName
-           bal = L.bndBalance bn
-           targetBal = getValOnByDate _target d
-        in 
-           max 0 $ bal - targetBal 
-
-    FeesPaidAt d fns ->
-      let
-        fSubMap = getFeeByName t (Just fns)
-        stmts = map F.feeStmt $ Map.elems fSubMap
-        ex s = case s of
-                 Nothing -> 0
-                 Just (Statement txns) -> sum $ getTxnAmt <$> filter (\x ->  d == getDate x) txns
-      in
-        sum $ map ex stmts
-
-    CurrentDueBondInt bns -> 
-      sum $ L.bndDueInt <$> viewDealBondsByNames t bns  
-
-    CurrentDueBondIntOverInt bns -> 
-      sum $ L.bndDueIntOverInt <$> viewDealBondsByNames t bns  
-
-    CurrentDueBondIntTotal bns -> sum (queryDeal t <$> [CurrentDueBondInt bns,CurrentDueBondIntOverInt bns])
-
-    CurrentDueFee fns -> sum $ F.feeDue <$> (feeMap Map.!) <$> fns
-
-    LiqCredit lqNames -> 
-      case liqProvider t of
-        Nothing -> 0
-        Just liqProviderM -> sum $ [ fromMaybe 0 (CE.liqCredit liq) | (k,liq) <- Map.assocs liqProviderM
-                                     , S.member k (S.fromList lqNames) ]
-
-    LiqBalance lqNames -> 
-      case liqProvider t of
-        Nothing -> 0
-        Just liqProviderM -> sum $ [ CE.liqBalance liq | (k,liq) <- Map.assocs liqProviderM
-                                     , S.member k (S.fromList lqNames) ]
-
-    RateCapNet rcName -> case rateCap t of
-                           Nothing -> error "No rate cap in the deal"
-                           Just rm -> case Map.lookup rcName rm of
-                                        Nothing -> error $ "No "++ rcName ++" Found in rate cap map with key"++ show (Map.keys rm)
-                                        Just rc -> H.rcNetCash rc
-    
-    RateSwapNet rsName -> case rateCap t of
-                           Nothing -> error "No rate swap in the deal"
-                           Just rm -> case Map.lookup rsName rm of
-                                        Nothing -> error $ "No "++ rsName ++" Found in rate swap map with key"++ show (Map.keys rm)
-                                        Just rc -> H.rcNetCash rc
-
-    WeightedAvgCurrentBondBalance d1 d2 bns ->
-      Map.foldr (\v a-> a + (L.weightAverageBalance d1 d2 v)) -- `debug` (" Avg Bal for bond"++ show (L.weightAverageBalance d1 d2 v)) )
-                0.0 
-                (getBondsByName t (Just bns))
-
-    WeightedAvgCurrentPoolBalance d1 d2 mPns ->
-      let 
-        txnsByPool = getAllCollectedTxns t mPns
-        waBalByPool = Map.map (CF.mflowWeightAverageBalance d1 d2 <$>) txnsByPool
-      in 
-        sum $ fromMaybe 0  <$> Map.elems waBalByPool
-
-    WeightedAvgOriginalBondBalance d1 d2 bns ->
-      let 
-        bnds = viewDealBondsByNames t bns
-        oBals = getOriginBalance <$> bnds
-        bgDates = L.originDate . L.bndOriginInfo <$> bnds -- `debug` ("bals"++show oBals++">>"++ show d1++"-"++show d2)
-      in 
-        sum $ (\(b,sd) -> mulBR b (yearCountFraction DC_ACT_365F (max d1 sd) d2)) <$> (zip oBals bgDates) -- `debug` ("bgDates"++show bgDates)
-
-    WeightedAvgOriginalPoolBalance d1 d2 mPns ->
-      mulBR 
-        (Map.findWithDefault 0.0 IssuanceBalance (getIssuanceStatsConsol t mPns))
-        (yearCountFraction DC_ACT_365F d1 d2)
-
-    CustomData s d ->
-        case custom t of 
-          Nothing -> 0 
-          Just mCustom ->
-              case mCustom Map.! s of 
-                CustomConstant v -> fromRational v 
-                CustomCurve cv -> getValOnByDate cv d
-                CustomDS ds -> queryDeal t (patchDateToStats d ds )
-
-    _ -> error ("Failed to query balance of -> "++ show s)
-
 queryCompound :: P.Asset a => TestDeal a -> Date -> DealStats -> Either String Rational 
-queryCompound t@TestDeal{accounts=accMap, bonds=bndMap} d s =
+queryCompound t@TestDeal{accounts=accMap, bonds=bndMap, ledgers=ledgersM, fees=feeMap, pool=pt}
+              d s =
   case s of
     Sum _s -> sum <$> sequenceA [ queryCompound t d __s | __s <- _s]
     Substract dss -> queryCompound t d (Subtract dss)
@@ -555,6 +194,7 @@ queryCompound t@TestDeal{accounts=accMap, bonds=bndMap} d s =
       queryCompound t d (Divide (CumulativeNetLoss mPns) (OriginalPoolBalance mPns))
     CumulativePoolDefaultedRateTill idx mPns ->
       queryCompound t d (Divide (PoolCumCollectionTill idx [NewDefaults] mPns) (OriginalPoolBalance mPns))
+    
     BondRate bn -> 
       case Map.lookup bn (bonds t) of 
         Just b@(L.Bond {}) -> Right . toRational $ L.bndRate b 
@@ -623,7 +263,374 @@ queryCompound t@TestDeal{accounts=accMap, bonds=bndMap} d s =
         q2 <- queryCompound t d (ReserveBalance ans)
         return $ max 0 (q2 - q1)
 
-    balanceQ -> Right . toRational $ queryDeal t balanceQ
+    CurrentBondBalance -> Right . toRational $ Map.foldr (\x acc -> getCurBalance x + acc) 0.0 bndMap
+    
+    OriginalBondBalance -> Right . toRational $ Map.foldr (\x acc -> getOriginBalance x + acc) 0.0 bndMap
+    
+    BondDuePrin bnds -> Right . toRational $ sum $ L.bndDuePrin <$> viewDealBondsByNames t bnds
+    
+    OriginalBondBalanceOf bnds -> Right . toRational $ sum $ getOriginBalance <$> viewDealBondsByNames t bnds
+
+    CurrentBondBalanceOf bns -> Right . toRational $ sum $ getCurBalance <$> viewDealBondsByNames t bns
+    
+    CurrentPoolBalance mPns ->
+      let
+        assetM = concat $ Map.elems $ getAllAsset t mPns
+      in 
+        Right . toRational $ sum $ P.getCurrentBal <$> assetM 
+    
+    CurrentPoolDefaultedBalance ->
+      Right . toRational $ 
+        foldl (\acc x -> acc + P.getCurrentBal x)
+              0.0 $
+              filter P.isDefaulted (getAllAssetList t)
+
+    DealIssuanceBalance mPns -> 
+      Right . toRational $ 
+        sum $ Map.findWithDefault 0.0 IssuanceBalance <$> Map.elems (getIssuanceStats t mPns)
+
+    OriginalPoolBalance mPns -> 
+      let 
+        statsConsol = getIssuanceStatsConsol t mPns 
+      in 
+        case Map.lookup IssuanceBalance statsConsol of 
+          Just v -> Right . toRational $ v
+          Nothing -> Left "No issuance balance found in the pool, pls specify it in the pool stats map `issuanceStat`"
+    
+    UnderlyingBondBalance mBndNames -> Left "Not implemented for underlying bond balance"
+ 
+    AllAccBalance -> Right . toRational $ sum $ map A.accBalance $ Map.elems accMap 
+    
+    AccBalance ans -> Right . toRational $ sum $ A.accBalance . (accMap Map.!) <$> ans
+
+    -- ^ negatave -> credit balance , postive -> debit balance
+    LedgerBalance ans ->
+      case ledgersM of 
+        Nothing -> Left ("No ledgers were modeled , failed to find ledger:"++show ans )
+        Just ledgersM -> Right . toRational $ sum $ LD.ledgBalance . (ledgersM Map.!) <$> ans
+    
+    LedgerBalanceBy dr ans ->
+      case ledgersM of 
+        Nothing -> Left ("No ledgers were modeled , failed to find ledger:"++show ans )
+        Just ledgersM -> 
+            let 
+              bs Credit = filter (<0) $ LD.ledgBalance . (ledgersM Map.!) <$> ans
+              bs Debit = filter (>0) $ LD.ledgBalance . (ledgersM Map.!) <$> ans
+            in 
+              Right . toRational $ abs $ sum (bs dr) -- `debug` ("dr"++show dr++">> bs dr"++ show (bs dr))
+
+    FutureCurrentPoolBalance mPns ->
+      case (mPns,pt) of 
+        (Nothing, MultiPool pm ) -> queryCompound t d (FutureCurrentPoolBalance (Just $ Map.keys pm))
+        (Just pids, MultiPool pm) -> 
+          if S.isSubsetOf  (S.fromList pids) (S.fromList (Map.keys pm)) then 
+            let 
+              m = Map.filterWithKey (\k _ -> S.member k (S.fromList pids)) pm
+            in 
+              Right . toRational $ sum $ Map.elems $ Map.map (`Pl.getIssuanceField` RuntimeCurrentPoolBalance) m 
+          else 
+            Left $ "Failed to find pool balance" ++ show pids ++ " from deal "++ show (Map.keys pm)
+        _ -> Left $ "Failed to find pool" ++ show (mPns) ++","++ show pt
+
+    FutureCurrentSchedulePoolBalance mPns ->
+      let 
+        scheduleFlowM = Map.elems $ view dealScheduledCashflow t
+      in 
+        Right . toRational $ sum $ maybe 0 (CF.mflowBalance . head . view CF.cashflowTxn) <$> scheduleFlowM
+    
+    FutureCurrentSchedulePoolBegBalance mPns ->
+      let 
+        scheduleFlowM = Map.elems $ view dealScheduledCashflow t
+      in 
+        Right . toRational $ sum $ maybe 0 (CF.mflowBegBalance . head . view CF.cashflowTxn) <$> scheduleFlowM
+    
+    FutureCurrentPoolBegBalance mPns ->
+      let 
+        ltc = getLatestCollectFrame t mPns
+      in 
+        Right . toRational $ sum $ maybe 0 CF.mflowBegBalance <$> ltc 
+
+    PoolCollectionHistory incomeType fromDay asOfDay mPns ->
+      Right . toRational $ sum fieldAmts
+        where
+          mTxns = Map.elems $ getAllCollectedTxns t mPns
+          subflow = sliceBy EI fromDay asOfDay $ concat $ fromMaybe [] <$> mTxns
+          fieldAmts = map (`CF.lookupSource` incomeType) subflow  
+
+    CumulativePoolDefaultedBalance mPns ->
+      let
+        latestCollect = getLatestCollectFrame t mPns
+        futureDefaults = sum $ Map.elems $ Map.map (maybe 0 (fromMaybe 0 . CF.tsCumDefaultBal )) $ latestCollect 
+      in
+        Right . toRational $ futureDefaults -- `debug` ("future Defaults at"++ show futureDefaults ++ show latestCollect)
+
+    CumulativePoolRecoveriesBalance mPns ->
+      let
+        latestCollect = getLatestCollectFrame t mPns
+        futureRecoveries = sum $ Map.elems $ Map.map (maybe 0 (fromMaybe 0 . CF.tsCumRecoveriesBal)) $ latestCollect 
+      in
+        Right . toRational $ futureRecoveries
+    
+    CumulativeNetLoss mPns ->
+      liftA2 
+        (-)
+        (queryCompound t d (CumulativePoolDefaultedBalance mPns))
+        (queryCompound t d (CumulativePoolRecoveriesBalance mPns))
+    
+    PoolCumCollection ps mPns ->
+      let 
+        collectedTxns = concat . Map.elems $ Map.map (fromMaybe []) $ getAllCollectedTxns t mPns
+        futureVals = sum $ (CF.lookupSource <$> collectedTxns) <*> ps
+        
+        poolStats = Map.elems $ getIssuanceStats t mPns
+        historyVals = sum $ (Map.findWithDefault 0.0 . poolSourceToIssuanceField <$> ps) <*> poolStats
+      in 
+        Right . toRational $ futureVals + historyVals
+    
+    PoolCumCollectionTill idx ps mPns -> 
+        let 
+          txnMap = Map.map (dropLastN (negate idx) . fromMaybe []) $ getAllCollectedTxns t mPns 
+          txnList = concat $ Map.elems txnMap
+          lookupList = CF.lookupSource <$> txnList
+          futureVals = sum $ lookupList <*> ps
+          sumMap = getIssuanceStatsConsol t mPns
+          historyVals = sum $ Map.findWithDefault 0 . poolSourceToIssuanceField <$> ps <*> [sumMap]
+        in 
+          Right . toRational $ futureVals + historyVals
+ 
+    PoolCurCollection ps mPns ->
+      let 
+        pCf = getLatestCollectFrame t mPns -- `debug` ("mPns"++ show mPns)
+        lastRows = Map.map (maybe 0 (\r -> sum (CF.lookupSource r <$> ps))) pCf -- `debug` ("Latest collect frame"++ show pCf)
+      in 
+        Right . toRational $ sum $ Map.elems lastRows -- `debug   ` ("lst row found"++ show lastRows)
+
+    PoolCollectionStats idx ps mPns -> 
+      let 
+        pCollectedTxns = getAllCollectedTxns t mPns
+        pStat = Map.map
+                  (\_x -> 
+                   let
+                     lookupIndx = length x + idx - 1
+                     x = fromMaybe [] _x
+                   in
+                     if (( lookupIndx >= length x ) ||  (lookupIndx <0)) then 
+                       Nothing
+                     else
+                       Just (x!!lookupIndx))
+                  pCollectedTxns
+      in
+        do
+          curPoolBalM <- sequenceA $
+                           Map.mapWithKey
+                             (\k v -> queryCompound t d (FutureCurrentPoolBalance (Just [k]))) 
+                             pStat
+          let poolStat = Map.mapWithKey
+                           (\k v -> 
+                              case v of
+                                Just _v -> sum $ CF.lookupSource _v <$> ps
+                                Nothing -> sum $ CF.lookupSourceM (fromRational (curPoolBalM Map.! k)) Nothing <$> ps)
+                           pStat -- `debug` ("query pool current bal" ++ show curPoolBalM )
+          return $ sum $ Map.elems $ toRational <$> poolStat -- `debug` ("query pool current stats"++ show poolStat)
+
+    FuturePoolScheduleCfPv asOfDay pm mPns -> 
+      let 
+        pScheduleFlow = view dealScheduledCashflow t
+        pCfTxns = Map.map (maybe [] (view CF.cashflowTxn)) $
+                    case mPns of 
+                      Nothing -> pScheduleFlow
+                      Just pIds -> Map.filterWithKey (\k _ -> S.member k (S.fromList pIds)) pScheduleFlow
+        txns = cutBy Exc Future asOfDay $ concat $ Map.elems pCfTxns
+        txnsCfs = CF.tsTotalCash <$> txns -- `debug` ("schedule cf as of "++ show asOfDay ++ ">>" ++ show txns)
+        txnsDs = getDate <$> txns
+        txnsRates = CF.mflowRate <$> txns
+      in
+        do 
+          scheduleBal <- queryCompound t d (FutureCurrentSchedulePoolBegBalance mPns)
+          curBal <- queryCompound t d (FutureCurrentPoolBalance mPns) 
+          let factor = case scheduleBal of 
+                         0.00 -> 0  
+                         _ -> curBal / scheduleBal -- `debug` ("cur Bal"++show curBal ++">> sheduleBal"++ show scheduleBal)
+          let cfForPv = (`mulBR` factor) <$> txnsCfs -- `debug` (">>> factor"++ show factor)
+          let pvs = case pm of
+                      PvRate r -> uncurry (A.pv2 r asOfDay) <$> zip txnsDs cfForPv
+                      -- TODO _ -> Left $ "Failed to use pricing method on pool" ++ show pm ++"on pool id"++ show mPns
+          return $ toRational $ sum pvs
+
+    BondsIntPaidAt d bns ->
+       let
+          stmts = map L.bndStmt $ viewDealBondsByNames t bns
+          ex s = case s of
+                   Nothing -> 0
+                   Just (Statement txns) 
+                     -> sum $ map getTxnAmt $
+                          filter (\y -> case getTxnComment y of 
+                                          (PayInt _ ) -> True
+                                          _ -> False)   $
+                          filter (\x -> d == getDate x) txns
+       in
+          Right . toRational $ sum $ map ex stmts
+
+    BondsPrinPaidAt d bns ->
+       let
+          stmts = map L.bndStmt $ viewDealBondsByNames t bns
+          ex s = case s of
+                   Nothing -> 0
+                   Just (Statement txns) 
+                     -> sum $ map getTxnAmt $
+                          filter (\y -> case getTxnComment y of 
+                                          (PayPrin _ ) -> True
+                                          _ -> False)   $
+                          filter (\x -> d == getDate x) txns
+       in
+          Right . toRational $ sum $ map ex stmts
+    
+    FeeTxnAmtBy d fns mCmt -> 
+      let 
+        fees = (feeMap Map.!) <$> fns -- Map.elems $ getFeeByName t (Just fns)
+      in  
+        Right . toRational $
+          case mCmt of 
+            Just cmt -> sum [ queryTxnAmtAsOf fee d cmt | fee <- fees ]
+            Nothing -> 
+              let 
+                _txn = concat [ getTxns (F.feeStmt fee) | fee <- fees ]
+              in 
+                sumTxn $ cutBy Inc Past d _txn 
+    
+    BondTxnAmtBy d bns mCmt -> 
+      let 
+        bnds = viewDealBondsByNames t bns
+      in 
+        Right . toRational $
+          case mCmt of
+            Just cmt -> sum [ queryTxnAmtAsOf bnd d cmt | bnd <- bnds ]
+            Nothing ->
+              let 
+                _txn = concat [ getTxns (L.bndStmt bnd) | bnd <- bnds ]
+              in 
+                sumTxn $ cutBy Inc Past d _txn
+
+    AccTxnAmtBy d ans mCmt -> 
+      let 
+        accs = (accMap Map.!) <$> ans
+      in 
+        Right . toRational $
+          case mCmt of
+            Just cmt -> sum [ queryTxnAmtAsOf acc d cmt | acc <- accs ]
+            Nothing ->
+              let 
+                _txn = concat [ getTxns (A.accStmt acc) | acc <- accs ]
+              in 
+                sumTxn $ cutBy Inc Past d _txn 
+
+    LedgerTxnAmt lns mCmt ->
+      case ledgersM of 
+        Nothing -> Left $ ("No ledgers were modeled , failed to find ledger:"++show lns )
+        Just ledgerm ->
+          let 
+            lgs = (ledgerm Map.!) <$> lns
+          in
+            case mCmt of
+              Just cmt -> Right . toRational $ sum [ queryTxnAmt lg cmt | lg <- lgs ]
+              Nothing -> Right . toRational $ sum [ LD.ledgBalance lg | lg <- lgs ]
+
+    BondBalanceGapAt d bName -> 
+        let 
+           bn@L.Bond{L.bndType = L.PAC _target} = bndMap Map.! bName
+           bal = L.bndBalance bn
+           targetBal = getValOnByDate _target d
+        in 
+           Right . toRational $ max 0 $ bal - targetBal 
+
+    FeesPaidAt d fns ->
+      let
+        fSubMap = getFeeByName t (Just fns)
+        stmts = map F.feeStmt $ Map.elems fSubMap
+        ex s = case s of
+                 Nothing -> 0
+                 Just (Statement txns) -> sum $ getTxnAmt <$> filter (\x ->  d == getDate x) txns
+      in
+        Right . toRational $ sum $ map ex stmts
+
+    CurrentDueBondInt bns -> 
+      Right . toRational $ sum $ L.bndDueInt <$> viewDealBondsByNames t bns  
+
+    CurrentDueBondIntOverInt bns -> 
+      Right . toRational $ sum $ L.bndDueIntOverInt <$> viewDealBondsByNames t bns  
+
+    CurrentDueBondIntTotal bns -> 
+      sum <$> sequenceA (queryCompound t d <$> [CurrentDueBondInt bns,CurrentDueBondIntOverInt bns])
+
+    CurrentDueFee fns -> 
+      Right . toRational $ sum $ F.feeDue <$> (feeMap Map.!) <$> fns
+
+    LiqCredit lqNames -> 
+      case liqProvider t of
+        Nothing -> Left $ "No Liquidation Provider modeled when looking for " ++ show s
+        Just liqProviderM -> Right . toRational $
+                               sum $ [ fromMaybe 0 (CE.liqCredit liq) | (k,liq) <- Map.assocs liqProviderM
+                                     , S.member k (S.fromList lqNames) ]
+
+    LiqBalance lqNames -> 
+      case liqProvider t of
+        Nothing -> Left $ "No Liquidation Provider modeled when looking for " ++ show s
+        Just liqProviderM -> Right . toRational $
+                               sum $ [ CE.liqBalance liq | (k,liq) <- Map.assocs liqProviderM
+                                     , S.member k (S.fromList lqNames) ]
+
+    RateCapNet rcName -> case rateCap t of
+                           Nothing -> Left $ "No Rate Cap modeled when looking for " ++ show s
+                           Just rm -> case Map.lookup rcName rm of
+                                        Nothing -> Left $ "No Rate Cap modeled when looking for " ++ show s
+                                        Just rc -> Right . toRational $ H.rcNetCash rc
+    
+    RateSwapNet rsName -> case rateCap t of
+                           Nothing -> Left $ "No Rate Swap modeled when looking for " ++ show s
+                           Just rm -> case Map.lookup rsName rm of
+                                        Nothing -> Left $ "No Rate Swap modeled when looking for " ++ show s
+                                        Just rc -> Right . toRational $ H.rcNetCash rc
+
+    WeightedAvgCurrentBondBalance d1 d2 bns ->
+      Right . toRational $ 
+        Map.foldr (\v a-> a + (L.weightAverageBalance d1 d2 v)) -- `debug` (" Avg Bal for bond"++ show (L.weightAverageBalance d1 d2 v)) )
+                  0.0 
+                  (getBondsByName t (Just bns))
+
+    WeightedAvgCurrentPoolBalance d1 d2 mPns ->
+      let 
+        txnsByPool = getAllCollectedTxns t mPns
+        waBalByPool = Map.map (CF.mflowWeightAverageBalance d1 d2 <$>) txnsByPool
+      in 
+        Right . toRational $ 
+          sum $ fromMaybe 0  <$> Map.elems waBalByPool
+
+    WeightedAvgOriginalBondBalance d1 d2 bns ->
+      let 
+        bnds = viewDealBondsByNames t bns
+        oBals = getOriginBalance <$> bnds
+        bgDates = L.originDate . L.bndOriginInfo <$> bnds -- `debug` ("bals"++show oBals++">>"++ show d1++"-"++show d2)
+      in 
+        Right . toRational $ 
+          sum $ (\(b,sd) -> mulBR b (yearCountFraction DC_ACT_365F (max d1 sd) d2)) <$> (zip oBals bgDates) -- `debug` ("bgDates"++show bgDates)
+
+    WeightedAvgOriginalPoolBalance d1 d2 mPns ->
+      Right . toRational $
+         mulBR
+          (Map.findWithDefault 0.0 IssuanceBalance (getIssuanceStatsConsol t mPns))
+          (yearCountFraction DC_ACT_365F d1 d2)
+
+    CustomData s d ->
+        case custom t of 
+          Nothing -> Left $ "No Custom data to query" ++ show s
+          Just mCustom ->
+              case mCustom Map.! s of 
+                CustomConstant v -> Right . toRational $ v 
+                CustomCurve cv -> Right . toRational $ getValOnByDate cv d
+                CustomDS ds -> queryCompound t d (patchDateToStats d ds )
+
+    _ -> Left ("Failed to query formula of -> "++ show s)
+    
 
 
 

--- a/src/Deal/DealQuery.hs
+++ b/src/Deal/DealQuery.hs
@@ -427,19 +427,19 @@ queryCompound t@TestDeal{accounts=accMap, bonds=bndMap, ledgers=ledgersM, fees=f
                         Nothing
                       else
                         Just (x!!lookupIndx))
-                  pCollectedTxns `debug` ("date"++show d++"Pool collection: "++ show pCollectedTxns)
+                  pCollectedTxns -- `debug` ("date"++show d++"Pool collection: "++ show pCollectedTxns)
       in
         do
           curPoolBalM <- sequenceA $
                            Map.mapWithKey
                              (\k v -> queryCompound t d (FutureCurrentPoolBalance (Just [k]))) 
-                             pStat `debug` ("date"++show d++"Pool stats collection: "++ show pStat)
+                             pStat -- `debug` ("date"++show d++"Pool stats collection: "++ show pStat)
           let poolStat = Map.mapWithKey
                            (\k v -> 
                               case v of
                                 Just _v -> sum $ CF.lookupSource _v <$> ps
                                 Nothing -> sum $ CF.lookupSourceM (fromRational (curPoolBalM Map.! k)) Nothing <$> ps)
-                           pStat  `debug` ("date"++show d++"query pool current pool stat 2" ++ show pStat )
+                           pStat  -- `debug` ("date"++show d++"query pool current pool stat 2" ++ show pStat )
           return $ sum $ Map.elems $ toRational <$> poolStat -- `debug` ("query pool current stats"++ show poolStat)
 
     FuturePoolScheduleCfPv asOfDay pm mPns -> 

--- a/src/Deal/DealValidation.hs
+++ b/src/Deal/DealValidation.hs
@@ -207,12 +207,12 @@ validateAction ((W.LiqSupport _ liqName CE.LiqToAcc [accName]):as) rs accKeys bn
   | otherwise = validateAction as rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
 
 validateAction ((W.LiqSupport _ liqName CE.LiqToFee feeNames):as) rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
-  | Set.isSubsetOf (Set.fromList feeNames) feeKeys || Set.notMember liqName liqProviderKeys 
+  | not (Set.isSubsetOf (Set.fromList feeNames) feeKeys) || Set.notMember liqName liqProviderKeys 
     = validateAction as (rs ++ [ErrorMsg (show feeNames++" not in "++show feeKeys++" Or "++liqName ++" not in "++ show liqProviderKeys)]) accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
   | otherwise = validateAction as rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
 
 validateAction ((W.LiqSupport _ liqName CE.LiqToBondInt bndNames):as) rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
-  | Set.isSubsetOf (Set.fromList bndNames) bndKeys || Set.notMember liqName liqProviderKeys 
+  | not (Set.isSubsetOf (Set.fromList bndNames) bndKeys) || Set.notMember liqName liqProviderKeys 
     = validateAction as (rs ++ [ErrorMsg (show bndNames++" not in "++show bndKeys++" Or "++liqName ++" not in "++ show liqProviderKeys)]) accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
   | otherwise = validateAction as rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
 

--- a/src/Deal/DealValidation.hs
+++ b/src/Deal/DealValidation.hs
@@ -201,19 +201,19 @@ validateAction ((W.LiquidatePool _ accName mPids):as) rs accKeys bndKeys bgNames
   | isJust mPids && not (Set.isSubsetOf (Set.fromList (fromMaybe [] mPids)) poolKeys) = validateAction as (rs ++ [ErrorMsg (show mPids++" not in "++show poolKeys)]) accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
   | otherwise = validateAction as rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
 
-validateAction ((W.LiqSupport _ liqName CE.LiqToAcc accName):as) rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
+validateAction ((W.LiqSupport _ liqName CE.LiqToAcc [accName]):as) rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
   | Set.notMember accName accKeys || Set.notMember liqName liqProviderKeys 
-    = validateAction as (rs ++ [ErrorMsg (accName++" not in "++show accKeys++" Or "++liqName ++" not in "++ show liqProviderKeys)]) accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
+    = validateAction as (rs ++ [ErrorMsg (show accName++" not in "++show accKeys++" Or "++liqName ++" not in "++ show liqProviderKeys)]) accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
   | otherwise = validateAction as rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
 
-validateAction ((W.LiqSupport _ liqName CE.LiqToFee feeName):as) rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
-  | Set.notMember feeName feeKeys || Set.notMember liqName liqProviderKeys 
-    = validateAction as (rs ++ [ErrorMsg (feeName++" not in "++show feeKeys++" Or "++liqName ++" not in "++ show liqProviderKeys)]) accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
+validateAction ((W.LiqSupport _ liqName CE.LiqToFee feeNames):as) rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
+  | Set.isSubsetOf (Set.fromList feeNames) feeKeys || Set.notMember liqName liqProviderKeys 
+    = validateAction as (rs ++ [ErrorMsg (show feeNames++" not in "++show feeKeys++" Or "++liqName ++" not in "++ show liqProviderKeys)]) accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
   | otherwise = validateAction as rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
 
-validateAction ((W.LiqSupport _ liqName CE.LiqToBondInt bndName):as) rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
-  | Set.notMember bndName bndKeys || Set.notMember liqName liqProviderKeys 
-    = validateAction as (rs ++ [ErrorMsg (bndName++" not in "++show bndKeys++" Or "++liqName ++" not in "++ show liqProviderKeys)]) accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
+validateAction ((W.LiqSupport _ liqName CE.LiqToBondInt bndNames):as) rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
+  | Set.isSubsetOf (Set.fromList bndNames) bndKeys || Set.notMember liqName liqProviderKeys 
+    = validateAction as (rs ++ [ErrorMsg (show bndNames++" not in "++show bndKeys++" Or "++liqName ++" not in "++ show liqProviderKeys)]) accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
   | otherwise = validateAction as rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
 
 validateAction ((W.LiqRepay _ _ accName liqName):as) rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys

--- a/src/Deal/DealValidation.hs
+++ b/src/Deal/DealValidation.hs
@@ -201,9 +201,19 @@ validateAction ((W.LiquidatePool _ accName mPids):as) rs accKeys bndKeys bgNames
   | isJust mPids && not (Set.isSubsetOf (Set.fromList (fromMaybe [] mPids)) poolKeys) = validateAction as (rs ++ [ErrorMsg (show mPids++" not in "++show poolKeys)]) accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
   | otherwise = validateAction as rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
 
-validateAction ((W.LiqSupport _ liqName _ accName):as) rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
+validateAction ((W.LiqSupport _ liqName CE.LiqToAcc accName):as) rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
   | Set.notMember accName accKeys || Set.notMember liqName liqProviderKeys 
     = validateAction as (rs ++ [ErrorMsg (accName++" not in "++show accKeys++" Or "++liqName ++" not in "++ show liqProviderKeys)]) accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
+  | otherwise = validateAction as rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
+
+validateAction ((W.LiqSupport _ liqName CE.LiqToFee feeName):as) rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
+  | Set.notMember feeName feeKeys || Set.notMember liqName liqProviderKeys 
+    = validateAction as (rs ++ [ErrorMsg (feeName++" not in "++show feeKeys++" Or "++liqName ++" not in "++ show liqProviderKeys)]) accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
+  | otherwise = validateAction as rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
+
+validateAction ((W.LiqSupport _ liqName CE.LiqToBondInt bndName):as) rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
+  | Set.notMember bndName bndKeys || Set.notMember liqName liqProviderKeys 
+    = validateAction as (rs ++ [ErrorMsg (bndName++" not in "++show bndKeys++" Or "++liqName ++" not in "++ show liqProviderKeys)]) accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
   | otherwise = validateAction as rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys
 
 validateAction ((W.LiqRepay _ _ accName liqName):as) rs accKeys bndKeys bgNames feeKeys liqProviderKeys rateSwapKeys rcKeys ledgerKeys rPoolKeys poolKeys

--- a/src/Ledger.hs
+++ b/src/Ledger.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE DeriveGeneric #-}
 
-module Ledger (Ledger(..),entryLog,LedgerName,queryGap,entryDebit,entryCredit,clearLedgersBySeq
+module Ledger (Ledger(..),entryLog,LedgerName,queryGap,clearLedgersBySeq
               ,queryDirection,entryLogByDr)
     where
 import qualified Data.Time as T
@@ -71,16 +71,6 @@ isTxnDirection Debit (TxnComments txns) = any (isTxnDirection Debit) txns
 isTxnDirection _ _ = False
 
 -- ^ credit is negative amount
-entryCredit :: Amount -> Date -> TxnComment -> Ledger -> Ledger 
-entryCredit amt d txn lg@Ledger{ledgName = ln}
-  | isTxnDirection Credit txn = entryLog (negate amt) d txn lg
-  | otherwise = undefined $ "Failed to write credit txn to ledger "++ ln ++ " with txn"++ show txn
-
-entryDebit :: Amount -> Date -> TxnComment -> Ledger -> Ledger 
-entryDebit amt d txn lg@Ledger{ledgName = ln}
-  | isTxnDirection Debit txn = entryLog amt d txn lg
-  | otherwise = undefined $ "Failed to write debit txn to ledger "++ ln ++ " with txn"++ show txn
-
 queryDirection :: Ledger -> (BookDirection ,Balance) 
 queryDirection (Ledger _ bal _)
   |  bal >= 0 = (Debit, bal)

--- a/src/Liability.hs
+++ b/src/Liability.hs
@@ -12,7 +12,7 @@ module Liability
   ,weightAverageBalance,calcZspread,payYield,scaleBond,totalDueInt
   ,buildRateResetDates,isAdjustble,StepUp(..),isStepUp,getDayCountFromInfo
   ,calcWalBond,patchBondFactor,fundWith,writeOff,InterestOverInterestType(..)
-  ,getCurBalance,setBondOrigDate
+  ,getCurBalance,setBondOrigDate,isFloaterBond
   ,bndOriginInfoLens,bndIntLens,getBeginRate,_Bond,_BondGroup)
   where
 
@@ -64,6 +64,10 @@ isAdjustble InterestByYield {} = False
 isAdjustble (CapRate r _ ) = isAdjustble r
 isAdjustble (FloorRate r _ ) = isAdjustble r
 isAdjustble (WithIoI r _) = isAdjustble r
+
+isFloaterBond :: InterestInfo -> Bool
+isFloaterBond Floater {} = True
+isFloaterBond _ = False
 
 isStepUp :: Bond -> Bool
 isStepUp Bond{bndStepUp = Nothing} = False

--- a/src/Pool.hs
+++ b/src/Pool.hs
@@ -185,7 +185,7 @@ pricingPoolFlow d pool@Pool{ futureCf = mCollectedCf, issuanceStat = mStat } fut
                                       Nothing -> 0 
                                       Just collectedCf -> 
                                         let 
-                                          collectedTxns = CF.getTsCashFlowFrame collectedCf
+                                          collectedTxns = view CF.cashflowTxn collectedCf
                                         in
                                           if null collectedTxns then 
                                             0 
@@ -205,7 +205,7 @@ pricingPoolFlow d pool@Pool{ futureCf = mCollectedCf, issuanceStat = mStat } fut
 
         PvRate discountRate ->
           let 
-            futureTxn = CF.getTsCashFlowFrame futureCfUncollected -- `debug` ("PV with cf"++ show d ++ ">>"++show futureCfUncollected)
+            futureTxn = view CF.cashflowTxn futureCfUncollected -- `debug` ("PV with cf"++ show d ++ ">>"++show futureCfUncollected)
             futureCfCash = CF.tsTotalCash <$> futureTxn
             futureDates = getDate <$> futureTxn
           in 

--- a/src/Stmt.hs
+++ b/src/Stmt.hs
@@ -245,6 +245,7 @@ getFlow comment =
       PurchaseAsset _ _-> Outflow
       IssuanceProceeds _ -> Inflow
       TxnDirection _ -> Noneflow
+      BookLedgerBy _ _ -> Noneflow
       TxnComments cmts ->  --TODO the direction of combine txns
         let 
           directionList = getFlow <$> cmts 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -30,7 +30,7 @@ module Types
   ,PricingMethod(..),CustomDataType(..),ResultComponent(..),DealStatType(..)
   ,ActionWhen(..)
   ,getDealStatType,getPriceValue,preHasTrigger
-  ,MyRatio
+  ,MyRatio,HowToPay(..)
   )
   
   where
@@ -615,6 +615,11 @@ data Limit = DuePct Rate            -- ^ up to % of total amount due
            | Multiple Limit Float   -- ^ factor of a limit
            deriving (Show,Ord,Eq,Read, Generic)
 
+data HowToPay = ByProRata
+              | BySequential
+              deriving (Show,Ord,Eq,Read, Generic)
+
+
 type BookItems = [BookItem]
 
 data BookItem = Item String Balance 
@@ -1007,6 +1012,7 @@ $(deriveJSON defaultOptions ''ResultComponent)
 
 $(deriveJSON defaultOptions ''PriceResult)
 $(deriveJSON defaultOptions ''CutoffFields)
+$(deriveJSON defaultOptions ''HowToPay)
 
 
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -799,15 +799,15 @@ data ActionWhen = EndOfPoolCollection             -- ^ waterfall executed at the
                 deriving (Show,Ord,Eq,Generic,Read)
 
 
-data ResultComponent = CallAt Date                                    -- ^ the date when deal called
-                     | DealStatusChangeTo Date DealStatus DealStatus  -- ^ record when status changed
-                     | BondOutstanding String Balance Balance         -- ^ when deal ends,calculate oustanding principal balance 
-                     | BondOutstandingInt String Balance Balance      -- ^ when deal ends,calculate oustanding interest due 
-                     | InspectBal Date DealStats Balance              -- ^ A bal value from inspection
-                     | InspectInt Date DealStats Int                  -- ^ A int value from inspection
-                     | InspectRate Date DealStats Micro               -- ^ A rate value from inspection
-                     | InspectBool Date DealStats Bool                -- ^ A bool value from inspection
-                     | RunningWaterfall Date ActionWhen               -- ^ running waterfall at a date 
+data ResultComponent = CallAt Date                                          -- ^ the date when deal called
+                     | DealStatusChangeTo Date DealStatus DealStatus String -- ^ record when & why status changed
+                     | BondOutstanding String Balance Balance               -- ^ when deal ends,calculate oustanding principal balance 
+                     | BondOutstandingInt String Balance Balance            -- ^ when deal ends,calculate oustanding interest due 
+                     | InspectBal Date DealStats Balance                    -- ^ A bal value from inspection
+                     | InspectInt Date DealStats Int                        -- ^ A int value from inspection
+                     | InspectRate Date DealStats Micro                     -- ^ A rate value from inspection
+                     | InspectBool Date DealStats Bool                      -- ^ A bool value from inspection
+                     | RunningWaterfall Date ActionWhen                     -- ^ running waterfall at a date 
                      | FinancialReport StartDate EndDate BalanceSheetReport CashflowReport
                      | InspectWaterfall Date (Maybe String) [DealStats] [String]
                      | ErrorMsg String

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -495,6 +495,7 @@ data DealStats = CurrentBondBalance
                | AllAccBalance
                | AccBalance [AccName]
                | LedgerBalance [String]
+               | LedgerBalanceBy BookDirection [String]
                | LedgerTxnAmt [String] (Maybe TxnComment)
                | ReserveBalance [AccName] 
                | ReserveGap [AccName]
@@ -846,6 +847,7 @@ instance ToJSON TxnComment where
   toJSON (TxnComments tcms) = Array $ V.fromList $ map toJSON tcms
   toJSON (PayGroupInt bns) = String $ T.pack $ "<PayGroupInt:"++ listToStrWithComma bns ++ ">"
   toJSON (PayGroupPrin bns) = String $ T.pack $ "<PayGroupPrin:"++ listToStrWithComma bns ++ ">"
+  toJSON (BookLedgerBy dr lName) = String $ T.pack $ "<BookLedger:"++ lName ++ ">"
   toJSON x = error $ "Not support for toJSON for "++show x
 
 instance FromJSON TxnComment where
@@ -974,7 +976,7 @@ data CustomDataType = CustomConstant Rational
 $(deriveJSON defaultOptions ''DealStatus)
 $(deriveJSON defaultOptions ''CutoffType)
 
-$(concat <$> traverse (deriveJSON defaultOptions) [''DealStats, ''PricingMethod, ''DealCycle, ''DateType, ''Period, 
+$(concat <$> traverse (deriveJSON defaultOptions) [''BookDirection, ''DealStats, ''PricingMethod, ''DealCycle, ''DateType, ''Period, 
   ''DatePattern, ''Table, ''BalanceSheetReport, ''BookItem, ''CashflowReport, ''Txn] )
 
 
@@ -1053,7 +1055,6 @@ instance FromJSONKey Threshold where
 
 
 $(deriveJSON defaultOptions ''RateAssumption)
-$(deriveJSON defaultOptions ''BookDirection)
 $(deriveJSON defaultOptions ''Direction)
 
 $(concat <$> traverse (deriveJSON defaultOptions) [''Limit] )

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -444,6 +444,7 @@ data TxnComment = PayInt [BondName]
                 | PayFeeYield FeeName
                 | Transfer AccName AccName 
                 | TransferBy AccName AccName Limit
+                | BookLedgerBy BookDirection String
                 | PoolInflow (Maybe [PoolId]) PoolSource
                 | LiquidationProceeds [PoolId]
                 | LiquidationSupport String
@@ -604,9 +605,9 @@ data Limit = DuePct Rate            -- ^ up to % of total amount due
            | DueCapAmt Balance      -- ^ up to $ amount 
            | KeepBalAmt DealStats   -- ^ pay till a certain amount remains in an account
            | DS DealStats           -- ^ transfer with limit described by a `DealStats`
-           | ClearLedger BookDirection String     -- ^ when transfer, clear the ledger by transfer amount
-           | ClearLedgerBySeq BookDirection [String]  -- ^ clear a direction to a sequence of ledgers
-           | BookLedger String      -- ^ when transfer, book the ledger by the transfer amount
+           -- | ClearLedger BookDirection String     -- ^ when transfer, clear the ledger by transfer amount
+           -- | ClearLedgerBySeq BookDirection [String]  -- ^ clear a direction to a sequence of ledgers
+           -- | BookLedger String      -- ^ when transfer, book the ledger by the transfer amount
            | RemainBalPct Rate      -- ^ pay till remain balance equals to a percentage of `stats`
            | TillTarget             -- ^ transfer amount which make target account up reach reserve balanace
            | TillSource             -- ^ transfer amount out till source account down back to reserve balance

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -12,7 +12,8 @@ module Util
     ,floorWith,slice,toPeriodRateByInterval, dropLastN, zipBalTs
     ,lastOf,findBox,safeDivide', safeDiv
     ,safeDivide,lstToMapByFn,paySequentially,payProRata,mapWithinMap
-    ,payInMap,adjustM
+    ,payInMap,adjustM,lookupAndApply,lookupAndUpdate,lookupAndApplies
+    ,lookupInMap,selectInMap
     -- for debug
     ,zyj
     )
@@ -395,6 +396,36 @@ mapWithinMap fn ks m = foldr (Map.adjust fn) m ks
 adjustM :: (Ord k, Applicative m) => (a -> m a) -> k -> Map.Map k a -> m (Map.Map k a)
 adjustM f = Map.alterF (traverse f)
 
+
+lookupAndApply :: Ord k => (a -> b) -> String -> k -> Map.Map k a -> Either String b
+lookupAndApply f errMsg key m =
+  case Map.lookup key m of
+    Nothing -> Left errMsg
+    Just a  -> Right $ f a
+
+lookupAndApplies :: Ord k => (a -> b) -> String -> [k] -> Map.Map k a -> Either String [b]
+lookupAndApplies f errMsg keys m 
+  = sequenceA $ (\x -> lookupAndApply f errMsg x m) <$> keys
+
+lookupAndUpdate :: (Show k, Ord k) => (a -> a) -> String -> [k] -> Map.Map k a -> Either String (Map.Map k a) 
+lookupAndUpdate f errMsg keys m 
+  | S.isSubsetOf inputKs mapKs = Right $ mapWithinMap f keys m
+  | otherwise = Left $ errMsg++":Missing keys, valid range "++ show mapKs ++ "But got:" ++ show inputKs
+  where 
+      inputKs = S.fromList keys
+      mapKs = Map.keysSet m
+
+lookupInMap :: (Show k, Ord k) => String -> [k] -> Map.Map k a -> Either String (Map.Map k a)
+lookupInMap = lookupAndUpdate id  
+
+
+selectInMap :: (Show k, Ord k) => String -> [k] -> Map.Map k a -> Either String (Map.Map k a)
+selectInMap errMsg keys m 
+  | S.isSubsetOf inputKs mapKs = Right $ (Map.filterWithKey (\k _ -> S.member k inputKs) m)
+  | otherwise = Left $ errMsg++":Missing keys, valid range "++ show mapKs ++ "But got:" ++ show inputKs
+  where 
+      inputKs = S.fromList keys
+      mapKs = Map.keysSet m
 
 ----- DEBUG/PRINT
 -- z y j : stands for chinese Zhao Yao Jing ,which is a mirror reveals the devil 

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -348,7 +348,7 @@ paySequentially :: Date -> Amount -> (a->Balance) -> (Amount->a->a) -> [a] -> [a
 paySequentially d amt getDueAmt payFn paidList []
   = (reverse paidList, amt)
 paySequentially d 0 getDueAmt payFn paidList tobePaidList
-  = (reverse (paidList++tobePaidList), 0)
+  = (reverse paidList++tobePaidList, 0)
 paySequentially d amt getDueAmt payFn paidList (l:tobePaidList)
   = let 
       dueAmt = getDueAmt l

--- a/src/Waterfall.hs
+++ b/src/Waterfall.hs
@@ -32,7 +32,7 @@ import Ledger (Ledger,LedgerName)
 
 
 
-data BookType = PDL DealStats [(LedgerName,DealStats)] -- Reverse PDL Debit reference, [(name,cap reference)]
+data BookType = PDL BookDirection DealStats [(LedgerName,DealStats)] -- Reverse PDL Debit reference, [(name,cap reference)]
               | ByAccountDraw LedgerName               -- Book amount equal to account draw amount
               | ByDS          LedgerName BookDirection DealStats     -- Book amount equal to a formula/deal stats
               deriving (Show,Generic,Eq,Ord)
@@ -51,10 +51,13 @@ data PayOrderBy = ByName
                 -- | InverseSeq PayOrderBy
                 deriving (Show,Generic,Eq,Ord)
 
+type BookLedger = (BookDirection, LedgerName) 
+type BookLedgers = (BookDirection, [LedgerName]) 
 
 data Action =
             -- Accounts 
             Transfer (Maybe Limit) AccountName AccountName (Maybe TxnComment)
+            | TransferAndBook (Maybe Limit) AccountName AccountName BookLedger (Maybe TxnComment)
             | TransferMultiple [(Maybe Limit, AccountName)] AccountName (Maybe TxnComment)
             -- Fee
             | CalcFee [FeeName]                                                            -- ^ calculate fee due amount in the fee names
@@ -88,7 +91,9 @@ data Action =
             | AccrueAndPayIntGroup (Maybe Limit) AccountName BondName PayOrderBy (Maybe ExtraSupport) 
             -- Bond - Balance
             | WriteOff (Maybe Limit) BondName
+            | WriteOffAndBook (Maybe Limit) BondName BookLedger
             | WriteOffBySeq (Maybe Limit) [BondName]
+            | WriteOffBySeqAndBook (Maybe Limit) [BondName] BookLedger
             | FundWith (Maybe Limit) AccountName BondName             -- ^ extra more funds from bond and deposit cash to account
             -- Pool/Asset change
             | BuyAsset (Maybe Limit) PricingMethod AccountName (Maybe PoolId)                       -- ^ buy asset from revolving assumptions using funds from account

--- a/src/Waterfall.hs
+++ b/src/Waterfall.hs
@@ -120,8 +120,9 @@ data Action =
             -- Trigger
             | RunTrigger DealCycle [String]        -- ^ update the trigger status during the waterfall execution
             -- Debug
-            | WatchVal (Maybe String) [DealStats]     -- ^ inspect vals during the waterfall execution
+            | WatchVal (Maybe String) [DealStats]  -- ^ inspect vals during the waterfall execution
             | Placeholder (Maybe String)
+            | ChangeStatus (Maybe Pre) DealStatus  -- change deal status
             deriving (Show,Generic,Eq,Ord)
 
 type DistributionSeq = [Action]

--- a/src/Waterfall.hs
+++ b/src/Waterfall.hs
@@ -101,7 +101,7 @@ data Action =
             | LiquidatePool PricingMethod AccountName  (Maybe [PoolId])                             -- ^ sell all assets and deposit proceeds to account
             -- TODO include a limit for LIquidatePool
             -- Liquidation support
-            | LiqSupport (Maybe Limit) CE.LiquidityProviderName CE.LiqDrawType AccountName  -- ^ draw credit and deposit to account/fee/bond interest/principal
+            | LiqSupport (Maybe Limit) CE.LiquidityProviderName CE.LiqDrawType [String]  -- ^ draw credit and deposit to account/fee/bond interest/principal
             | LiqRepay (Maybe Limit) CE.LiqRepayType AccountName CE.LiquidityProviderName   -- ^ repay liquidity facility
             | LiqYield (Maybe Limit) AccountName CE.LiquidityProviderName                   -- ^ repay compensation to liquidity facility
             | LiqAccrue [CE.LiquidityProviderName]                                            -- ^ accure premium/due interest of liquidity facility

--- a/swagger.json
+++ b/swagger.json
@@ -19240,7 +19240,7 @@
             "name": "BSD 3"
         },
         "title": "Hastructure API",
-        "version": "0.40.5"
+        "version": "0.40.7"
     },
     "openapi": "3.0.0",
     "paths": {

--- a/swagger.json
+++ b/swagger.json
@@ -1832,7 +1832,17 @@
                     {
                         "properties": {
                             "contents": {
-                                "$ref": "#/components/schemas/DealStatus"
+                                "items": [
+                                    {
+                                        "$ref": "#/components/schemas/Pre"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/DealStatus"
+                                    }
+                                ],
+                                "maxItems": 2,
+                                "minItems": 2,
+                                "type": "array"
                             },
                             "tag": {
                                 "enum": [
@@ -14794,10 +14804,13 @@
                                     },
                                     {
                                         "$ref": "#/components/schemas/DealStatus"
+                                    },
+                                    {
+                                        "type": "string"
                                     }
                                 ],
-                                "maxItems": 3,
-                                "minItems": 3,
+                                "maxItems": 4,
+                                "minItems": 4,
                                 "type": "array"
                             },
                             "tag": {

--- a/swagger.json
+++ b/swagger.json
@@ -19275,7 +19275,7 @@
             "name": "BSD 3"
         },
         "title": "Hastructure API",
-        "version": "0.40.5"
+        "version": "0.40.9"
     },
     "openapi": "3.0.0",
     "paths": {

--- a/swagger.json
+++ b/swagger.json
@@ -131,6 +131,54 @@
                             "contents": {
                                 "items": [
                                     {
+                                        "$ref": "#/components/schemas/Limit"
+                                    },
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "items": [
+                                            {
+                                                "$ref": "#/components/schemas/BookDirection"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ],
+                                        "maxItems": 2,
+                                        "minItems": 2,
+                                        "type": "array"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/TxnComment"
+                                    }
+                                ],
+                                "maxItems": 5,
+                                "minItems": 5,
+                                "type": "array"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "TransferAndBook"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "title": "TransferAndBook",
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contents": {
+                                "items": [
+                                    {
                                         "items": {
                                             "items": [
                                                 {
@@ -1096,6 +1144,48 @@
                                         "$ref": "#/components/schemas/Limit"
                                     },
                                     {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "items": [
+                                            {
+                                                "$ref": "#/components/schemas/BookDirection"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ],
+                                        "maxItems": 2,
+                                        "minItems": 2,
+                                        "type": "array"
+                                    }
+                                ],
+                                "maxItems": 3,
+                                "minItems": 3,
+                                "type": "array"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "WriteOffAndBook"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "title": "WriteOffAndBook",
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contents": {
+                                "items": [
+                                    {
+                                        "$ref": "#/components/schemas/Limit"
+                                    },
+                                    {
                                         "items": {
                                             "type": "string"
                                         },
@@ -1118,6 +1208,51 @@
                             "contents"
                         ],
                         "title": "WriteOffBySeq",
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contents": {
+                                "items": [
+                                    {
+                                        "$ref": "#/components/schemas/Limit"
+                                    },
+                                    {
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "items": [
+                                            {
+                                                "$ref": "#/components/schemas/BookDirection"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ],
+                                        "maxItems": 2,
+                                        "minItems": 2,
+                                        "type": "array"
+                                    }
+                                ],
+                                "maxItems": 3,
+                                "minItems": 3,
+                                "type": "array"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "WriteOffBySeqAndBook"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "title": "WriteOffBySeqAndBook",
                         "type": "object"
                     },
                     {
@@ -4260,6 +4395,9 @@
                             "contents": {
                                 "items": [
                                     {
+                                        "$ref": "#/components/schemas/BookDirection"
+                                    },
+                                    {
                                         "$ref": "#/components/schemas/DealStats"
                                     },
                                     {
@@ -4279,8 +4417,8 @@
                                         "type": "array"
                                     }
                                 ],
-                                "maxItems": 2,
-                                "minItems": 2,
+                                "maxItems": 3,
+                                "minItems": 3,
                                 "type": "array"
                             },
                             "tag": {
@@ -6244,6 +6382,38 @@
                             "contents"
                         ],
                         "title": "LedgerBalance",
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contents": {
+                                "items": [
+                                    {
+                                        "$ref": "#/components/schemas/BookDirection"
+                                    },
+                                    {
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
+                                    }
+                                ],
+                                "maxItems": 2,
+                                "minItems": 2,
+                                "type": "array"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "LedgerBalanceBy"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "title": "LedgerBalanceBy",
                         "type": "object"
                     },
                     {
@@ -10573,86 +10743,6 @@
                             "contents"
                         ],
                         "title": "DS",
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "contents": {
-                                "items": [
-                                    {
-                                        "$ref": "#/components/schemas/BookDirection"
-                                    },
-                                    {
-                                        "type": "string"
-                                    }
-                                ],
-                                "maxItems": 2,
-                                "minItems": 2,
-                                "type": "array"
-                            },
-                            "tag": {
-                                "enum": [
-                                    "ClearLedger"
-                                ],
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "tag",
-                            "contents"
-                        ],
-                        "title": "ClearLedger",
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "contents": {
-                                "items": [
-                                    {
-                                        "$ref": "#/components/schemas/BookDirection"
-                                    },
-                                    {
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "type": "array"
-                                    }
-                                ],
-                                "maxItems": 2,
-                                "minItems": 2,
-                                "type": "array"
-                            },
-                            "tag": {
-                                "enum": [
-                                    "ClearLedgerBySeq"
-                                ],
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "tag",
-                            "contents"
-                        ],
-                        "title": "ClearLedgerBySeq",
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "contents": {
-                                "type": "string"
-                            },
-                            "tag": {
-                                "enum": [
-                                    "BookLedger"
-                                ],
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "tag",
-                            "contents"
-                        ],
-                        "title": "BookLedger",
                         "type": "object"
                     },
                     {
@@ -18550,6 +18640,35 @@
                             "contents"
                         ],
                         "title": "TransferBy",
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contents": {
+                                "items": [
+                                    {
+                                        "$ref": "#/components/schemas/BookDirection"
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "maxItems": 2,
+                                "minItems": 2,
+                                "type": "array"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "BookLedgerBy"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "title": "BookLedgerBy",
                         "type": "object"
                     },
                     {

--- a/swagger.json
+++ b/swagger.json
@@ -1409,7 +1409,10 @@
                                         "$ref": "#/components/schemas/LiqDrawType"
                                     },
                                     {
-                                        "type": "string"
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "type": "array"
                                     }
                                 ],
                                 "maxItems": 4,
@@ -1824,6 +1827,25 @@
                             "contents"
                         ],
                         "title": "Placeholder",
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contents": {
+                                "$ref": "#/components/schemas/DealStatus"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "ChangeStatus"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "title": "ChangeStatus",
                         "type": "object"
                     }
                 ]
@@ -19240,7 +19262,7 @@
             "name": "BSD 3"
         },
         "title": "Hastructure API",
-        "version": "0.40.8"
+        "version": "0.40.5"
     },
     "openapi": "3.0.0",
     "paths": {

--- a/swagger.json
+++ b/swagger.json
@@ -19240,7 +19240,7 @@
             "name": "BSD 3"
         },
         "title": "Hastructure API",
-        "version": "0.40.7"
+        "version": "0.40.8"
     },
     "openapi": "3.0.0",
     "paths": {

--- a/swagger.json
+++ b/swagger.json
@@ -19240,7 +19240,7 @@
             "name": "BSD 3"
         },
         "title": "Hastructure API",
-        "version": "0.40.4"
+        "version": "0.40.5"
     },
     "openapi": "3.0.0",
     "paths": {

--- a/swagger.json
+++ b/swagger.json
@@ -1671,6 +1671,25 @@
                         ],
                         "title": "WatchVal",
                         "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contents": {
+                                "type": "string"
+                            },
+                            "tag": {
+                                "enum": [
+                                    "Placeholder"
+                                ],
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "tag",
+                            "contents"
+                        ],
+                        "title": "Placeholder",
+                        "type": "object"
                     }
                 ]
             },
@@ -11799,25 +11818,6 @@
                     {
                         "properties": {
                             "contents": {
-                                "$ref": "#/components/schemas/Pool_AssetUnion"
-                            },
-                            "tag": {
-                                "enum": [
-                                    "SoloPool"
-                                ],
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "tag",
-                            "contents"
-                        ],
-                        "title": "SoloPool",
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "contents": {
                                 "additionalProperties": {
                                     "$ref": "#/components/schemas/Pool_AssetUnion"
                                 },
@@ -11863,25 +11863,6 @@
             },
             "PoolType_FixedAsset": {
                 "oneOf": [
-                    {
-                        "properties": {
-                            "contents": {
-                                "$ref": "#/components/schemas/Pool_FixedAsset"
-                            },
-                            "tag": {
-                                "enum": [
-                                    "SoloPool"
-                                ],
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "tag",
-                            "contents"
-                        ],
-                        "title": "SoloPool",
-                        "type": "object"
-                    },
                     {
                         "properties": {
                             "contents": {
@@ -11933,25 +11914,6 @@
                     {
                         "properties": {
                             "contents": {
-                                "$ref": "#/components/schemas/Pool_Installment"
-                            },
-                            "tag": {
-                                "enum": [
-                                    "SoloPool"
-                                ],
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "tag",
-                            "contents"
-                        ],
-                        "title": "SoloPool",
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "contents": {
                                 "additionalProperties": {
                                     "$ref": "#/components/schemas/Pool_Installment"
                                 },
@@ -11997,25 +11959,6 @@
             },
             "PoolType_Lease": {
                 "oneOf": [
-                    {
-                        "properties": {
-                            "contents": {
-                                "$ref": "#/components/schemas/Pool_Lease"
-                            },
-                            "tag": {
-                                "enum": [
-                                    "SoloPool"
-                                ],
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "tag",
-                            "contents"
-                        ],
-                        "title": "SoloPool",
-                        "type": "object"
-                    },
                     {
                         "properties": {
                             "contents": {
@@ -12067,25 +12010,6 @@
                     {
                         "properties": {
                             "contents": {
-                                "$ref": "#/components/schemas/Pool_Loan"
-                            },
-                            "tag": {
-                                "enum": [
-                                    "SoloPool"
-                                ],
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "tag",
-                            "contents"
-                        ],
-                        "title": "SoloPool",
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "contents": {
                                 "additionalProperties": {
                                     "$ref": "#/components/schemas/Pool_Loan"
                                 },
@@ -12131,25 +12055,6 @@
             },
             "PoolType_Mortgage": {
                 "oneOf": [
-                    {
-                        "properties": {
-                            "contents": {
-                                "$ref": "#/components/schemas/Pool_Mortgage"
-                            },
-                            "tag": {
-                                "enum": [
-                                    "SoloPool"
-                                ],
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "tag",
-                            "contents"
-                        ],
-                        "title": "SoloPool",
-                        "type": "object"
-                    },
                     {
                         "properties": {
                             "contents": {
@@ -12201,25 +12106,6 @@
                     {
                         "properties": {
                             "contents": {
-                                "$ref": "#/components/schemas/Pool_ProjectedCashflow"
-                            },
-                            "tag": {
-                                "enum": [
-                                    "SoloPool"
-                                ],
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "tag",
-                            "contents"
-                        ],
-                        "title": "SoloPool",
-                        "type": "object"
-                    },
-                    {
-                        "properties": {
-                            "contents": {
                                 "additionalProperties": {
                                     "$ref": "#/components/schemas/Pool_ProjectedCashflow"
                                 },
@@ -12265,25 +12151,6 @@
             },
             "PoolType_Receivable": {
                 "oneOf": [
-                    {
-                        "properties": {
-                            "contents": {
-                                "$ref": "#/components/schemas/Pool_Receivable"
-                            },
-                            "tag": {
-                                "enum": [
-                                    "SoloPool"
-                                ],
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "tag",
-                            "contents"
-                        ],
-                        "title": "SoloPool",
-                        "type": "object"
-                    },
                     {
                         "properties": {
                             "contents": {
@@ -19254,7 +19121,7 @@
             "name": "BSD 3"
         },
         "title": "Hastructure API",
-        "version": "0.31.2"
+        "version": "0.40.1"
     },
     "openapi": "3.0.0",
     "paths": {

--- a/swagger.json
+++ b/swagger.json
@@ -19275,7 +19275,7 @@
             "name": "BSD 3"
         },
         "title": "Hastructure API",
-        "version": "0.40.9"
+        "version": "0.40.10"
     },
     "openapi": "3.0.0",
     "paths": {

--- a/swagger.json
+++ b/swagger.json
@@ -19121,7 +19121,7 @@
             "name": "BSD 3"
         },
         "title": "Hastructure API",
-        "version": "0.40.1"
+        "version": "0.40.4"
     },
     "openapi": "3.0.0",
     "paths": {

--- a/test/DealTest/DealTest.hs
+++ b/test/DealTest/DealTest.hs
@@ -48,7 +48,7 @@ emptyCase = D.TestDeal {
   ,D.accounts = Map.empty
   ,D.fees = Map.empty
   ,D.bonds = Map.empty
-  ,D.pool = D.SoloPool (P.Pool {P.assets=[]})
+  ,D.pool = D.MultiPool $ Map.fromList [(PoolConsol, (P.Pool {P.assets=[]}))] 
   ,D.waterfall = Map.empty
   ,D.collects = []
 }
@@ -87,7 +87,8 @@ baseCase = D.TestDeal {
                              ,L.bndStmt=Nothing})
                          ]
            )
-  ,D.pool = D.SoloPool (P.Pool {P.assets=[AB.Mortgage
+  ,D.pool = D.MultiPool $
+              (Map.fromList [(PoolConsol, (P.Pool {P.assets=[AB.Mortgage
                                          AB.MortgageOriginalInfo{
                                            AB.originBalance=4000
                                            ,AB.originRate=Fix DC_ACT_365F 0.085
@@ -104,7 +105,7 @@ baseCase = D.TestDeal {
                                ,P.futureCf=Just (CF.CashFlowFrame dummySt [])
                                ,P.asOfDate = T.fromGregorian 2022 1 1
                                ,P.issuanceStat = Nothing
-                               ,P.extendPeriods = Nothing})
+                               ,P.extendPeriods = Nothing}))])
    ,D.waterfall = Map.fromList [(W.DistributionDay Amortizing, [
                                  (W.PayInt Nothing "General" ["A"] Nothing)
                                  ,(W.PayPrin Nothing "General" ["A"] Nothing)

--- a/test/DealTest/ResecDealTest.hs
+++ b/test/DealTest/ResecDealTest.hs
@@ -68,7 +68,7 @@ baseCase = D.TestDeal {
                              ,L.bndStmt=Nothing})
                          ]
            )
-  ,D.pool = D.SoloPool (P.Pool {P.assets=[AB.Mortgage
+  ,D.pool = D.MultiPool (Map.fromList [(PoolConsol, (P.Pool {P.assets=[AB.Mortgage
                                          AB.MortgageOriginalInfo{
                                            AB.originBalance=4000
                                            ,AB.originRate=Fix DC_ACT_365F 0.085
@@ -85,7 +85,7 @@ baseCase = D.TestDeal {
                                ,P.futureCf=Just (CF.CashFlowFrame dummySt [])
                                ,P.asOfDate = T.fromGregorian 2022 1 1
                                ,P.issuanceStat = Nothing
-                               ,P.extendPeriods = Nothing})
+                               ,P.extendPeriods = Nothing}))])
    ,D.waterfall = Map.fromList [(W.DistributionDay Amortizing, [
                                  (W.PayInt Nothing "General" ["A"] Nothing)
                                  ,(W.PayPrin Nothing "General" ["A"] Nothing)

--- a/test/MainTest.hs
+++ b/test/MainTest.hs
@@ -73,6 +73,7 @@ tests = testGroup "Tests" [AT.mortgageTests
                            ,DT.triggerTests
                            ,DT.dateTests
                            ,DT.liqProviderTest
+                           ,DT.poolFlowTest
                            ,DT2.queryTests
                            ,UtilT.daycountTests1
                            ,UtilT.daycountTests2

--- a/test/MainTest.hs
+++ b/test/MainTest.hs
@@ -64,6 +64,7 @@ tests = testGroup "Tests" [AT.mortgageTests
                            ,BT.bndConsolTest
                            ,LT.curveTests
                            ,LT.pvTests
+                           ,LT.seqFunTest
                            -- --,LT.queryStmtTests
                            ,LT.datesTests
                            ,LT.prorataTests

--- a/test/UT/AccountTest.hs
+++ b/test/UT/AccountTest.hs
@@ -14,6 +14,11 @@ import Deal.DealQuery (queryCompound)
 import Deal.DealBase
 import qualified Cashflow as CF
 
+import qualified Pool as P
+import Control.Lens hiding (element,Empty)
+import Control.Lens.TH
+import Data.Map.Lens
+
 import qualified Data.Time as T
 import qualified Data.Map as Map
 import UT.DealTest (td2)
@@ -80,7 +85,7 @@ reserveAccTest =
                ,CF.MortgageFlow (toDate "20220801") 110 20 10 0 0 0 0 0 Nothing Nothing Nothing
                ,CF.MortgageFlow (toDate "20220901") 90 20 10 0 0 0 0 0 Nothing Nothing Nothing
                ,CF.MortgageFlow (toDate "20221001") 70 20 10 0 0 0 0 0 Nothing Nothing Nothing]
-    ttd = (setFutureCF td2 testCFs) {accounts = accMap}
+    ttd = set (dealPool . poolTypePool . (ix PoolConsol) . P.poolFutureCf) (Just testCFs) td2 {accounts = accMap}
   in 
     testGroup "Test On Reserve Acc"
      [
@@ -94,12 +99,12 @@ reserveAccTest =
           (calcTargetAmount ttd (toDate "20220801") acc2)
      ,testCase "test on reserve account gap" $
         assertEqual "pct reserve gap "
-        (Right 0)
-        (queryCompound ttd (toDate "20220826") (ReserveGapAt (toDate "20220826") ["A1"]))
+          (Right 0)
+          (queryCompound ttd (toDate "20220826") (ReserveGapAt (toDate "20220826") ["A1"]))
      ,testCase "test on reserve account gap" $
         assertEqual "fix reserve gap "
-        (Right 60)
-        (queryCompound ttd (toDate "20220801") (ReserveGapAt (toDate "20220801") ["A2"]))
+          (Right 60)
+          (queryCompound ttd (toDate "20220801") (ReserveGapAt (toDate "20220801") ["A2"]))
      ]
 
 

--- a/test/UT/DealTest.hs
+++ b/test/UT/DealTest.hs
@@ -5,6 +5,7 @@ where
 import Test.Tasty
 import Test.Tasty.HUnit
 import Deal
+import Deal.DealQuery (queryCompound)
 
 import qualified Accounts as A
 import qualified Stmt as Stmt
@@ -302,10 +303,10 @@ poolFlowTest =
 queryTests =  testGroup "deal stat query Tests"
   [
     let
-     currentDefBal = queryDeal td2 CurrentPoolDefaultedBalance
+     currentDefBal = queryCompound td2 epocDate CurrentPoolDefaultedBalance
     in
      testCase "query current assets in defaulted status" $
-     assertEqual "should be 200" 200 currentDefBal
+     assertEqual "should be 200" (Right 200) currentDefBal
   ]
 
 triggerTests = testGroup "Trigger Tests"

--- a/test/UT/DealTest.hs
+++ b/test/UT/DealTest.hs
@@ -250,6 +250,7 @@ baseDeal = D.TestDeal {
                                            ,AB.period=Monthly
                                            ,AB.startDate=(T.fromGregorian 2022 1 1)
                                            ,AB.prinType= AB.Level
+                                           ,AB.obligor = Nothing
                                            ,AB.prepaymentPenalty = Nothing}
                                          4000
                                          0.085
@@ -257,6 +258,7 @@ baseDeal = D.TestDeal {
                                          Nothing
                                          AB.Current]
                  ,P.futureCf=Nothing
+                 ,P.extendPeriods = Nothing
                  ,P.asOfDate = T.fromGregorian 2022 1 1
                  ,P.issuanceStat = Just $ Map.fromList [(RuntimeCurrentPoolBalance, 70)]})]
    ,D.waterfall = Map.fromList [(W.DistributionDay Amortizing, [

--- a/test/UT/DealTest2.hs
+++ b/test/UT/DealTest2.hs
@@ -93,7 +93,8 @@ td = D.TestDeal {
                                ,L.bndStmt=Nothing})
                          ]
            )
-  ,D.pool = D.SoloPool $ 
+  ,D.pool = D.MultiPool $ 
+              Map.fromList [(PoolConsol,
                       P.Pool {P.assets=[AB.Mortgage
                                          AB.MortgageOriginalInfo{
                                            AB.originBalance=4000
@@ -126,6 +127,7 @@ td = D.TestDeal {
                  ,P.futureCf=Nothing
                  ,P.asOfDate = T.fromGregorian 2022 1 1
                  ,P.issuanceStat = Nothing}
+                )]
    ,D.waterfall = Map.fromList [(W.DistributionDay Amortizing, [
                                   (W.PayFee Nothing "General" ["Service-Fee"] Nothing)
                                  ,(W.PayInt Nothing "General" ["A"] Nothing)

--- a/test/UT/DealTest2.hs
+++ b/test/UT/DealTest2.hs
@@ -6,6 +6,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
 import Deal
 
+import Deal.DealQuery (queryCompound)
 import qualified Accounts as A
 import qualified Stmt as S
 import qualified Pool as P
@@ -215,23 +216,23 @@ tdBondGroup = td { D.bonds = bondGroups,
 queryTests =  testGroup "Deal Group Test"
   [
     let
-     currBndGrpBal = queryDeal tdBondGroup (CurrentBondBalanceOf ["A"])
+     currBndGrpBal = queryCompound tdBondGroup epocDate (CurrentBondBalanceOf ["A"])
     in
      testCase "group bond balance" $
-     assertEqual "should be 2500" 2500 currBndGrpBal
+     assertEqual "should be 2500" (Right 2500) currBndGrpBal
     ,let 
         bndsFound = D.viewDealAllBonds tdBondGroup
      in 
         testCase "view viewDealAllBonds " $
         assertEqual "should be 3" 3 (length bndsFound)
     ,let 
-        totalBndBal = queryDeal tdBondGroup CurrentBondBalance 
+        totalBndBal = queryCompound tdBondGroup epocDate CurrentBondBalance 
     in 
         testCase "total bond balance" $
-        assertEqual "should be 3000" 3000 totalBndBal
+        assertEqual "should be 3000" (Right 3000) totalBndBal
     ,let
-        originBndbal = queryDeal tdBondGroup (OriginalBondBalanceOf ["A"])
+        originBndbal = queryCompound tdBondGroup epocDate (OriginalBondBalanceOf ["A"])
     in
         testCase "original bond balance" $
-        assertEqual "should be 5000" 5000 originBndbal
+        assertEqual "should be 5000" (Right 5000) originBndbal
   ]

--- a/test/UT/LibTest.hs
+++ b/test/UT/LibTest.hs
@@ -3,7 +3,7 @@ module UT.LibTest(curveTests
                  ,datesTests
                  ,prorataTests
                  ,tsOperationTests
-                 ,pvTests)
+                 ,pvTests,seqFunTest)
 where
 
 import Test.Tasty
@@ -140,4 +140,24 @@ pvTests =
         assertEqual "12M"
         1
         1
+    ]
+
+seqFunTest = 
+    let 
+      a =1 
+    in 
+    testGroup "seq fun test"
+    [
+     testCase "clear:even" $
+      assertEqual "Good for first"
+      [100,20,0]
+      (paySeqLiabilitiesAmt 120 [100,20,0])
+    ,testCase "shortfall" $
+      assertEqual "Good for first" 
+      [100,20,0]
+      (paySeqLiabilitiesAmt 120 [100,20,10])
+    ,testCase "over " $
+      assertEqual "Good for first"
+      [100,10,0]
+      (paySeqLiabilitiesAmt 120 [100,10,0])
     ]

--- a/test/UT/RateHedgeTest.hs
+++ b/test/UT/RateHedgeTest.hs
@@ -28,14 +28,14 @@ capRateTests =
     [
       testCase "Accure out of scope" $
         assertEqual "before"
-          rc
+          (Right rc)
           (accrueRC td2 (Lib.toDate "20231201") indexAssump rc)
       ,testCase "Accure out of scope" $
         assertEqual "after" 
-          rc
+          (Right rc)
           (accrueRC td2 (Lib.toDate "20280101") indexAssump rc)
       ,testCase "Accrue on flat curve" $
         assertEqual "netCash" 
-          5.0
-          (rcNetCash rc1)
+          (Right 5.0)
+          (rcNetCash <$> rc1)
     ]


### PR DESCRIPTION
- [x] Fix : order of pay sequence when remain amt is 0
- [x] Fix : step-up coupon set for floater bond
- [x] Enhance: remove SOLO pool id
- [x] add mis-match error  for assumption vs asset
- [x] #246 
- [x] [LedgerBalanceBy](https://github.com/yellowbean/Hastructure/pull/245/commits/c5db6aaf8687cc053071e8b1e5e23c6620c5ccf2)
- [x] Fix github action : Make docker images for each single `dev` release ( version starts with "a")
- [x] Expose all errors in DealQuery functions()